### PR TITLE
Add android support for getting version from git branch

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_git_branch.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_git_branch.rb
@@ -39,7 +39,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform
+        [:ios, :mac, :android].include? platform
       end
     end
   end


### PR DESCRIPTION
This operation is not specific to iOS, so makes sense to enable it on Android as well.