### PR TITLE
Increment last part of build number

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ version = get_version_number_from_git_branch(pattern: 'release-#')
 Increment/set build number in Info.plist of specific target. Doesn't use agvtool (unlike default increment_version_number).
 
 ```ruby
-increment_build_number_in_plist # Automatically increments build number.
+increment_build_number_in_plist # Automatically increments the last part of the build number.
 increment_build_number_in_plist(
   build_number: 42 # set build number to 42
 )

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
@@ -5,7 +5,10 @@ module Fastlane
         if params[:build_number]
           next_build_number = params[:build_number]
         else
-          next_build_number = (GetBuildNumberFromPlistAction.run(params).to_i + 1).to_s
+          current_build_number = GetBuildNumberFromPlistAction.run(params)
+          build_array = current_build_number.split(".").map(&:to_i)
+          build_array[-1] = build_array[-1]+1            
+          next_build_number = build_array.join(".")
         end
 
         if Helper.test?

--- a/lib/fastlane/plugin/versioning/version.rb
+++ b/lib/fastlane/plugin/versioning/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Versioning
-    VERSION = "0.2.7"
+    VERSION = "0.2.8"
   end
 end

--- a/spec/fixtures/plist/Info.plist
+++ b/spec/fixtures/plist/Info.plist
@@ -38,7 +38,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1234</string>
+	<string>0.9.14.1</string>
 	<key>LSApplicationCategoryType</key>
 	<string></string>
 	<key>LSRequiresIPhoneOS</key>

--- a/spec/get_build_number_from_plist_spec.rb
+++ b/spec/get_build_number_from_plist_spec.rb
@@ -10,14 +10,14 @@ describe Fastlane::Actions::GetBuildNumberFromPlistAction do
       result = Fastlane::FastFile.new.parse("lane :test do
         get_build_number_from_plist
       end").runner.execute(:test)
-      expect(result).to eq("1234")
+      expect(result).to eq("0.9.14.1")
     end
 
     it "should set BUILD_NUMBER shared value" do
       Fastlane::FastFile.new.parse("lane :test do
         get_build_number_from_plist
       end").runner.execute(:test)
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1234")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.9.14.1")
     end
 
     after do

--- a/spec/increment_build_number_in_plist_spec.rb
+++ b/spec/increment_build_number_in_plist_spec.rb
@@ -25,11 +25,11 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
 
     it "should set explicitly provided version number to Info.plist" do
       result = Fastlane::FastFile.new.parse("lane :test do
-        increment_build_number_in_plist(build_number: '4321')
+        increment_build_number_in_plist(build_number: '1.9.4.1')
       end").runner.execute(:test)
 
-      expect(current_version).to eq("4321")
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("4321")
+      expect(current_version).to eq("1.9.4.1")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1.9.4.1")
     end
 
     it "should increment build number by default and set it to Info.plist" do
@@ -37,8 +37,8 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
         increment_build_number_in_plist
       end").runner.execute(:test)
 
-      expect(current_version).to eq("1235")
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1235")
+      expect(current_version).to eq("0.9.14.2")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.9.14.2")
     end
 
     after do


### PR DESCRIPTION
## Increment last part of build number

The current version of `increment_vuild_number_in_plist` action works properly only with an integer build number (e.g. `42` will be bumped to `43`).

The proposal in this pull request is to allow the use _advanced_ builder number. The idea is to bump the last part of the build number.
For example, you can have a project using a build number based on version number.
Let's say you defined `2.0.0` as the version number and `2.0.0.1` as the build number. By bumping only the last part of the build number, it will result in `2.0.0.2`.
Of course, it will always work the same way for integer number because it is the last and only part.

From my point of view, I do not see any real use case where it makes sense to allow major, minor, patch, build, etc... build number increment as the `increment_version_number_in_plist` action.

Another improvement would be to add an option for the action to automatically base the build number on the version number.

A simple example is illustrated in the following table.

Version number | Build number | Incremented build number
-------------- | ------------ | ------------------------
`2.0.0` | `2.0.0.1` | `2.0.0.2`
`2.0.0` | `2.0.0.2` | `2.0.0.3`
`2.0.1` | `2.0.0.3` | `2.0.1.1`
