### PR TITLE
Add support for reading Bitrise CI build numbers

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/ci_build_number.rb
+++ b/lib/fastlane/plugin/versioning/actions/ci_build_number.rb
@@ -38,6 +38,10 @@ module Fastlane
           return ENV['BITBUCKET_BUILD_NUMBER']
         end
 
+        if ENV.key?('BITRISE_BUILD_NUMBER')
+          return ENV['BITRISE_BUILD_NUMBER']
+        end
+
         if ENV.key?('BUDDYBUILD_BUILD_NUMBER')
           return ENV['BUDDYBUILD_BUILD_NUMBER']
         end

--- a/spec/ci_build_number_spec.rb
+++ b/spec/ci_build_number_spec.rb
@@ -127,6 +127,18 @@ describe Fastlane::Actions::CiBuildNumberAction do
       ENV.delete('BITBUCKET_BUILD_NUMBER')
     end
 
+    it "Returns build number defined in BITRISE_BUILD_NUMBER environment variable if running on Bitrise" do
+      ENV['BITRISE_BUILD_NUMBER'] = '42'
+
+      result = Fastlane::FastFile.new.parse("lane :test do
+          ci_build_number
+        end").runner.execute(:test)
+
+      expect(result).to eq('42')
+
+      ENV.delete('BITRISE_BUILD_NUMBER')
+    end
+
     it "Returns build number defined in BUDDYBUILD_BUILD_NUMBER environment variable if running on BuddyBuild" do
       ENV['BUDDYBUILD_BUILD_NUMBER'] = '42'
 


### PR DESCRIPTION
This reads build numbers from `BITRISE_BUILD_NUMBER` when running on [Bitrise](https://bitrise.io)