### PR TITLE
Use `other_action` to call other actions

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_git_branch.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_git_branch.rb
@@ -5,7 +5,7 @@ module Fastlane
         if Helper.test?
           branch = 'releases/release-1.3.5'
         else
-          branch = Actions.git_branch
+          branch = other_action.git_branch
         end
 
         pattern = params[:pattern].dup


### PR DESCRIPTION
When calling other actions, you should be using the [other_action](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/other_action.rb) method. Ex. `other_action.git_branch`. Using the ruby module `Actions` can and will result in unexpected behaviors, like we've recently encountered in a project we've been working on. More details below.

When using this plugin with our CI (Bitrise), we were getting failures that said, `[!] Cannot find version number in git branch 'HEAD' by pattern 'v#'`. We began digging and found the problem to be the use of the `Actions.git_branch` instead of `other_action.git_branch`. This is because when using `Actions.git_branch`, this is not calling into the `git_branch` plugin but instead is calling a class method on the `Actions` module. These are two totally separate things and it appears the use of `Actions.git_branch` isn't meant to be used in third party plugins such as this one.

Using `Actions.git_branch`:
```
$ be fastlane run get_version_number_from_git_branch pattern:'v#'
[✔] 🚀
+----------------------------+---------+--------------------------------------------------------------------------------------------------------------------+
|                                                                       Used plugins                                                                        |
+----------------------------+---------+--------------------------------------------------------------------------------------------------------------------+
| Plugin                     | Version | Action                                                                                                             |
+----------------------------+---------+--------------------------------------------------------------------------------------------------------------------+
| fastlane-plugin-git_tags   | 0.1.1   | git_tags                                                                                                           |
| fastlane-plugin-versioning | 0.3.4   | get_version_number_from_git_branch get_version_number_from_plist get_build_number_from_plist ci_build_number       |
|                            |         | increment_version_number_in_plist get_app_store_version_number get_info_plist_path increment_build_number_in_plist |
+----------------------------+---------+--------------------------------------------------------------------------------------------------------------------+

[10:13:44]: ------------------------------------------------
[10:13:44]: --- Step: get_version_number_from_git_branch ---
[10:13:44]: ------------------------------------------------

[!] Cannot find version number in git branch 'HEAD' by pattern 'v#'
```

Using `other_action.git_branch`:
```
$ be fastlane run get_version_number_from_git_branch pattern:'v#'
[✔] 🚀
+----------------------------+---------+--------------------------------------------------------------------------------------------------------------------+
|                                                                       Used plugins                                                                        |
+----------------------------+---------+--------------------------------------------------------------------------------------------------------------------+
| Plugin                     | Version | Action                                                                                                             |
+----------------------------+---------+--------------------------------------------------------------------------------------------------------------------+
| fastlane-plugin-git_tags   | 0.1.1   | git_tags                                                                                                           |
| fastlane-plugin-versioning | 0.3.4   | get_version_number_from_git_branch get_version_number_from_plist get_build_number_from_plist ci_build_number       |
|                            |         | increment_version_number_in_plist get_app_store_version_number get_info_plist_path increment_build_number_in_plist |
+----------------------------+---------+--------------------------------------------------------------------------------------------------------------------+

[10:13:55]: ------------------------------------------------
[10:13:55]: --- Step: get_version_number_from_git_branch ---
[10:13:55]: ------------------------------------------------
[10:13:55]: Result: 5.2
```