### PR TITLE
[Feature] - xcode11 project build / version number build setting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@
 [![Gem](https://img.shields.io/gem/v/fastlane-plugin-versioning.svg?style=flat)](http://rubygems.org/gems/fastlane-plugin-versioning)
 [![fastlane Plugin Badge](https://rawcdn.githack.com/fastlane/fastlane/master/fastlane/assets/plugin-badge.svg)](https://rubygems.org/gems/fastlane-plugin-versioning)
 
-# MAINTAINERS WANTED
-
-Unfortunately I don't have enough time to maintain this project. If you want to become a maintainer of this project, please, open the issue or [email](mailto:siarhei.fedartsou@gmail.com) me.
-
 ## Getting Started
 
 This project is a [fastlane](https://github.com/fastlane/fastlane) plugin. To get started with fastlane-plugin-versioning, add it to your project by running:
@@ -20,14 +16,24 @@ fastlane add_plugin versioning
 ## About versioning
 
 Extends fastlane versioning actions. Allows to set/get versions without using agvtool and do some other small tricks.
-Note that all schemes that you pass to actions like `increment_version_number_in_plist` or `get_info_plist_path` in `scheme` parameter must be shared.
-To make your scheme shared go to "Manage schemes" in Xcode and tich "Shared" checkbox near your scheme.
+Note that all schemes that you pass to actions like `increment_version_number_in_plist`, `increment_build_number_in_xcodeproj` or `get_info_plist_path` in `scheme` parameter must be shared.
+To make your scheme shared go to "Manage schemes" in Xcode and tick "Shared" checkbox near your scheme.
+
+
+### what is this `plist_build_setting_support` stuff about?!
+If you have a xcodeproject and have updated to Xcode 11, you'll notice that if you change your build and version numbers through the UI, the actual numbers are now stored inside build settings inside build confiugration. The Info.plist file -- where they used to be stored -- now contains build setting variables (looks like `$(CURRENT_PROJECT_VERSION)` or `$(MARKETING_VERSION)`, for build number and version number respectively).
+If you are at this migration 'turning point', you have two options. you can either:
+1. simply add `plist_build_setting_support: true` to your plist action parameters
+2. change the command to be the xcodeproj variants - i.e. `increment_version_number_in_xcodeproj` or `increment_build_number_in_xcodeproj`
+
+these also apply to the `getters` of build and version numbers. 
+We will leave the plist actions in, as for those consumers who are limited to their upgrade path.
 
 ## Actions
 
 ### increment_version_number_in_plist
 
-Increment/set version number in Info.plist of specific target. Doesn't use agvtool (unlike default increment_version_number).
+Increment/set the version number in a Info.plist of specific target. Doesn't use `agvtool` (unlike default `increment_version_number`).
 
 ```ruby
 increment_version_number_in_plist # Automatically increment patch version number.
@@ -61,19 +67,41 @@ increment_version_number_in_plist(
   # (optional)
   target: 'TestTarget' # or `scheme`
 )
+
+increment_version_number_in_plist(
+  # specify specific version number (optional, omitting it increments patch version number)
+  version_number: '2.1.1',   
+  # (optional, you must specify the path to your main Xcode project if it is not in the project root directory
+  # or if you have multiple xcodeproj's in the root directory)
+  xcodeproj: './path/to/MyApp.xcodeproj'  
+  # (optional)
+  target: 'TestTarget' # or `scheme`
+  plist_build_setting_support: true, # optional, and defaulting to false.
+  # setting this will resolve the version number using the relevant build settings from your xcodeproj.
+)
+
 ```
+
+#### plist_build_setting_support
+`get_version_number_from_plist` supports the `plist_build_setting_support` flag, and will either use the other parameters you pass to resolve a particular build configuration to edit, _OR_ change __ALL__ of them.
+
 
 ### get_version_number_from_plist
 
-Get version number from Info.plist of specific target. Doesn't use agvtool (unlike default get_version_number).
+Get the version number from an Info.plist of specific target. Doesn't use `agvtool` (unlike default `get_version_number`).
 
 ```ruby
 version = get_version_number_from_plist(xcodeproj: 'Project.xcodeproj', # optional
                                         target: 'TestTarget', # optional, or `scheme`
                                         # optional, must be specified if you have different Info.plist build settings
                                         # for different build configurations
+                                        plist_build_setting_support: true, # optional, and defaulting to false. setting this will 
+                                        # resolve the version number using the relevant build settings from your xcodeproj.
                                         build_configuration_name: 'Release')
 ```
+
+#### plist_build_setting_support
+`get_version_number_from_plist` supports the `plist_build_setting_support` flag, and will either use the other parameters you pass to resolve a particular build configuration to retrieve, _OR_ pick the first it finds.
 
 ### get_app_store_version_number
 
@@ -101,7 +129,7 @@ version = get_version_number_from_git_branch(pattern: 'release-#')
 
 ### increment_build_number_in_plist
 
-Increment/set build number in Info.plist of specific target. Doesn't use agvtool (unlike default increment_version_number).
+Increment/set build number in Info.plist of specific target. Doesn't use `agvtool` (unlike default `increment_version_number`).
 
 ```ruby
 increment_build_number_in_plist # Automatically increments the last part of the build number.
@@ -110,16 +138,115 @@ increment_build_number_in_plist(
 )
 ```
 
+#### plist_build_setting_support
+`increment_build_number_in_plist` supports the `plist_build_setting_support` flag, and will either use the other parameters you pass to resolve a particular build configuration to edit, _OR_ change __ALL__ of them.
+
 ### get_build_number_from_plist
 
-Get build number from Info.plist of specific target. Doesn't use agvtool (unlike default get_build_number).
+Get the build number from an Info.plist of specific target. Doesn't use `agvtool` (unlike default `get_build_number`).
 
 ```ruby
 version = get_build_number_from_plist(xcodeproj: "Project.xcodeproj", # optional
                                         target: 'TestTarget', # optional, or `scheme`
+                                        plist_build_setting_support: true, # optional, and defaulting to false. setting this will 
+                                        # resolve the build number using the relevant build settings from your xcodeproj.
                                         build_configuration_name: 'Release') # optional, must be specified if you have different Info.plist build settings for different build configurations
 ```
 
+#### plist_build_setting_support
+`get_build_number_from_plist` supports the `plist_build_setting_support` flag, and will either use the other parameters you pass to resolve a particular build configuration to retrieve, _OR_ pick the first it finds.
+
+### get_build_number_from_xcodeproj
+
+Get the build number from a xcodeproj - specific to a target. Doesn't use agvtool (unlike default `get_build_number`).
+
+```ruby
+version = get_build_number_from_xcodeproj(xcodeproj: "Project.xcodeproj", # optional
+                                        target: 'TestTarget', # optional, or `scheme`
+                                        build_configuration_name: 'Release') # optional, must be specified if you have different Info.plist build settings for different build configurations
+```
+
+### get_version_number_from_xcodeproj
+
+Get the version number from a xcodeproj - specific to a target. Doesn't use agvtool (unlike default `get_build_number`).
+
+```ruby
+version = get_version_number_from_xcodeproj(xcodeproj: 'Project.xcodeproj', # optional
+                                        target: 'TestTarget', # optional, or `scheme`
+                                        # optional, must be specified if you have different Info.plist build settings
+                                        # for different build configurations
+                                        build_configuration_name: 'Release')
+```
+
+### increment_version_number_in_xcodeproj
+
+Increment/set the version number in a xcodeproj of specific target. Doesn't use `agvtool` (unlike default `increment_version_number`).
+
+```ruby
+increment_version_number_in_xcodeproj # Automatically increment patch version number.
+increment_version_number_in_xcodeproj(
+  bump_type: 'patch' # Automatically increment patch version number
+)
+increment_version_number_in_xcodeproj(
+  bump_type: 'minor' # Automatically increment minor version number
+)
+increment_version_number_in_xcodeproj(
+  bump_type: 'minor',
+  omit_zero_patch_version: true # if true omits zero in patch version(so 42.10.0 will become 42.10 and 42.10.1 will remain 42.10.1), default is false
+)
+increment_version_number_in_xcodeproj(
+  bump_type: 'major' # Automatically increment major version number
+)
+increment_version_number_in_xcodeproj(
+  version_number: '2.1.1' # Set a specific version number
+)
+increment_version_number_in_xcodeproj(
+  # Automatically increment patch version number. Use App Store version number as a source.
+  version_source: 'appstore'
+)
+
+increment_version_number_in_xcodeproj(
+  # specify specific version number (optional, omitting it increments patch version number)
+  version_number: '2.1.1',   
+  # (optional, you must specify the path to your main Xcode project if it is not in the project root directory
+  # or if you have multiple xcodeproj's in the root directory)
+  xcodeproj: './path/to/MyApp.xcodeproj'  
+  # (optional)
+  target: 'TestTarget' # or `scheme`
+)
+
+```
+
+### get_version_number_from_plist
+
+Get version number from Info.plist of specific target. Doesn't use agvtool (unlike default `get_version_number`).
+
+```ruby
+version = get_version_number_from_plist(xcodeproj: 'Project.xcodeproj', # optional
+                                        target: 'TestTarget', # optional, or `scheme`
+                                        # optional, must be specified if you have different Info.plist build settings
+                                        # for different build configurations
+                                        plist_build_setting_support: true, # optional, and defaulting to false. setting this will 
+                                        # resolve the version number using the relevant build settings from your xcodeproj.
+                                        build_configuration_name: 'Release')
+```
+
+#### plist_build_setting_support
+`get_version_number_from_plist` supports the `plist_build_setting_support` flag, and will either use the other parameters you pass to resolve a particular build configuration to retrieve, _OR_ pick the first it finds.
+
+### get_app_store_version_number
+
+
+```ruby
+version = get_app_store_version_number(xcodeproj: 'Project.xcodeproj', # optional
+                                        target: 'TestTarget', # optional, or `scheme`
+                                        # optional, must be specified if you have different Info.plist build settings
+                                        # for different build configurations
+                                        build_configuration_name: 'Release')
+)
+version = get_app_store_version_number(bundle_id: 'com.apple.Numbers')
+
+```
 
 ### get_info_plist_path
 
@@ -141,6 +268,8 @@ increment_build_number_in_plist(
   build_number: ci_build_number
 )
 ```
+
+
 
 ## Issues and Feedback
 

--- a/lib/fastlane/plugin/versioning/actions/get_app_store_version_number.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_app_store_version_number.rb
@@ -9,11 +9,11 @@ module Fastlane
           bundle_id = params[:bundle_id]
         else
           if Helper.test?
-            plist = "/tmp/fastlane/tests/fastlane/Info.plist"
+            plist = "/tmp/fastlane/tests/fastlane/plist/Info.plist"
           else
             plist = GetInfoPlistPathAction.run(params)
           end
-          bundle_id = GetInfoPlistValueAction.run(path: plist, key: 'CFBundleIdentifier')
+          bundle_id = GetInfoPlistValueAction.run(path: plist, key: 'CFBundleIdentifier') # TODO: add same kind of flag to support build setting variables
         end
 
         uri = URI("http://itunes.apple.com/lookup?bundleId=#{bundle_id}")

--- a/lib/fastlane/plugin/versioning/actions/get_app_store_version_number.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_app_store_version_number.rb
@@ -42,7 +42,7 @@ module Fastlane
                              env_name: "FL_APPSTORE_VERSION_NUMBER_BUNDLE_ID",
                              description: "Bundle ID of the application",
                              optional: true,
-                             conflicting_options: [:xcodeproj, :target, :scheme, :build_configuration_name],
+                             conflicting_options: %i[xcodeproj target scheme build_configuration_name],
                              is_string: true),
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
                              env_name: "FL_VERSION_NUMBER_PROJECT",
@@ -56,12 +56,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :target,
                              env_name: "FL_VERSION_NUMBER_TARGET",
                              optional: true,
-                             conflicting_options: [:bundle_id, :scheme],
+                             conflicting_options: %i[bundle_id scheme],
                              description: "Specify a specific target if you have multiple per project, optional"),
           FastlaneCore::ConfigItem.new(key: :scheme,
                              env_name: "FL_VERSION_NUMBER_SCHEME",
                              optional: true,
-                             conflicting_options: [:bundle_id, :target],
+                             conflicting_options: %i[bundle_id target],
                              description: "Specify a specific scheme if you have multiple per project, optional"),
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                              optional: true,
@@ -75,7 +75,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform
+        %i[ios mac].include? platform
       end
     end
   end

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
@@ -3,7 +3,7 @@ module Fastlane
     class GetBuildNumberFromPlistAction < Action
       def self.run(params)
         if Helper.test?
-          plist = "/tmp/fastlane/tests/fastlane/Info.plist"
+          plist = "/tmp/fastlane/tests/fastlane/plist/Info.plist"
         else
           plist = GetInfoPlistPathAction.run(params)
         end

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
@@ -9,6 +9,11 @@ module Fastlane
         end
 
         version_number = GetInfoPlistValueAction.run(path: plist, key: 'CFBundleVersion')
+        if version_number =~ /\$\(([\w\-]+)\)/
+          UI.important "info plist value is a build setting. will now resolve from xcodeproject."
+          version_number = GetBuildNumberFromXcodeprojAction.run(params)
+        end
+
         # Store the number in the shared hash
         Actions.lane_context[SharedValues::BUILD_NUMBER] = version_number
       end

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
@@ -65,7 +65,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                               description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                               is_string: false,
-                              default_value: false) #TODO: for backwards compatibility, should eventually turn to true?
+                              default_value: false) # TODO: for backwards compatibility, should eventually turn to true?
         ]
       end
 
@@ -80,7 +80,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform
+        %i[ios mac].include? platform
       end
     end
   end

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
@@ -14,10 +14,6 @@ module Fastlane
         else
           UI.important "build number will originate from plist."
           build_number = GetInfoPlistValueAction.run(path: plist, key: 'CFBundleVersion')
-          if build_number =~ /\$\(([\w\-]+)\)/
-            UI.important "info plist value is a build setting. will now resolve from xcodeproject."
-            build_number = GetBuildNumberFromXcodeprojAction.run(params)
-          end
         end
 
         # Store the number in the shared hash
@@ -35,7 +31,8 @@ module Fastlane
 
       def self.details
         [
-          "This action will return the current build number set on your project's Info.plist."
+          "This action will return the current build number set on your project's Info.plist.",
+          "note that you can pass plist_build_setting_support: true, in which case it will return from your xcodeproj."
         ].join(' ')
       end
 
@@ -65,7 +62,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                               description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                               is_string: false,
-                              default_value: false) # TODO: for backwards compatibility, should eventually turn to true?
+                              default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
@@ -22,7 +22,7 @@ module Fastlane
           build_number = get_first_build_number_in_xcodeproj(params)
         end
 
-        Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number # TODO: compared to ths plist getter, this is a slightly different meaning. BUILD_NUMBER is like <major>.<minor>.<patch>.<build> as opposed to <build>
+        Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number
         build_number
       end
 
@@ -53,14 +53,14 @@ module Fastlane
         end
 
         build_number = target.resolved_build_setting('CURRENT_PROJECT_VERSION', true)
-        UI.user_error! 'Cannot resolve build number build setting.' if build_number.nil? || build_number.empty? # TODO: come back to this message
+        UI.user_error! 'Cannot resolve build number build setting.' if build_number.nil? || build_number.empty?
 
         if !(build_configuration_name = params[:build_configuration_name]).nil?
           build_number = build_number[build_configuration_name]
-          UI.user_error! "Cannot resolve CURRENT_PROJECT_VERSION build setting for #{build_configuration_name}." if plist.nil?
+          UI.user_error! "Cannot resolve $(CURRENT_PROJECT_VERSION) build setting for #{build_configuration_name}." if plist.nil?
         else
           build_number = build_number.values.compact.uniq
-          UI.user_error! 'Cannot accurately resolve CURRENT_PROJECT_VERSION build setting, try specifying :build_configuration_name.' if build_number.count > 1
+          UI.user_error! 'Cannot accurately resolve $(CURRENT_PROJECT_VERSION) build setting, try specifying :build_configuration_name.' if build_number.count > 1
           build_number = build_number.first
         end
 
@@ -73,7 +73,7 @@ module Fastlane
         project.select_scheme
 
         build_number = project.build_settings(key: 'CURRENT_PROJECT_VERSION')
-        # TODO: USER_ERROR message same as in line 38?
+        UI.user_error! "Cannot resolve $(CURRENT_PROJECT_VERSION) in for the scheme #{config.scheme} with the name #{params.configuration}" if build_number.nil? || build_number.empty?
         build_number
       end
 
@@ -82,11 +82,11 @@ module Fastlane
       #####################################################
 
       def self.description
-        "Get the version number of your project"
+        "Get the build number of your project"
       end
 
       def self.details
-        'TODO:'
+        'Gets the $(CURRENT_PROJECT_VERSION) build setting using the specified parameters, or the first if not enough parameters are passed.'
       end
 
       def self.available_options
@@ -112,7 +112,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                                        optional: true,
                                        description: "Specify a specific build configuration if you have different build settings for each configuration")
-
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
@@ -1,129 +1,128 @@
 module Fastlane
-    module Actions
-      class GetBuildNumberFromXcodeprojAction < Action
-        require 'xcodeproj'
-        require 'pathname'
-  
-        def self.run(params)
-          unless params[:xcodeproj]
-            if Helper.test?
-              params[:xcodeproj] = "/tmp/fastlane/tests/fastlane/xcodeproj/versioning_fixture_project.xcodeproj"
-            else
-              params[:xcodeproj] = Dir["*.xcodeproj"][0] unless params[:xcodeproj]
-            end
-          end
+  module Actions
+    class GetBuildNumberFromXcodeprojAction < Action
+      require 'xcodeproj'
+      require 'pathname'
 
-          if params[:target]
-            build_number = get_build_number_using_target(params)
-          elsif params[:build_configuration_name] && params[:scheme] 
-            build_number = get_build_number_using_scheme(params)
+      def self.run(params)
+        unless params[:xcodeproj]
+          if Helper.test?
+            params[:xcodeproj] = "/tmp/fastlane/tests/fastlane/xcodeproj/versioning_fixture_project.xcodeproj"
           else
-            UI.important "not enough information to pick a specific target or build configuration. taking the first one from the project"
-            build_number = get_first_build_number_in_xcodeproj(params)
+            params[:xcodeproj] = Dir["*.xcodeproj"][0] unless params[:xcodeproj]
           end
-
-          Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number #TODO: compared to ths plist getter, this is a slightly different meaning. BUILD_NUMBER is like <major>.<minor>.<patch>.<build> as opposed to <build>
-          build_number
-        end
-  
-        def self.get_first_build_number_in_xcodeproj(params)
-          project = Xcodeproj::Project.open(params[:xcodeproj])
-          configs = project.objects.select { |obj| select_build_configuration_predicate(nil, obj) }
-          configs.first.build_settings["CURRENT_PROJECT_VERSION"]
-        end
-  
-        private_class_method
-        def self.select_build_configuration_predicate(name, configuration)
-          is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.build_settings["PRODUCT_BUNDLE_IDENTIFIER"].nil?
-          is_build_valid_configuration &&= configuration.name == name unless name.nil?
-          return is_build_valid_configuration
         end
 
-        def self.get_build_number_using_target(params)
-          project = Xcodeproj::Project.open(params[:xcodeproj])
-          if params[:target]
-            target = project.targets.detect { |t| t.name == params[:target] }
-          else
-            # firstly we are trying to find modern application target
-            target = project.targets.detect do |t|
-              t.kind_of?(Xcodeproj::Project::Object::PBXNativeTarget) &&
-                t.product_type == 'com.apple.product-type.application'
-            end
-            target = project.targets[0] if target.nil?
+        if params[:target]
+          build_number = get_build_number_using_target(params)
+        elsif params[:build_configuration_name] && params[:scheme]
+          build_number = get_build_number_using_scheme(params)
+        else
+          UI.important "not enough information to pick a specific target or build configuration. taking the first one from the project"
+          build_number = get_first_build_number_in_xcodeproj(params)
+        end
+
+        Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number # TODO: compared to ths plist getter, this is a slightly different meaning. BUILD_NUMBER is like <major>.<minor>.<patch>.<build> as opposed to <build>
+        build_number
+      end
+
+      def self.get_first_build_number_in_xcodeproj(params)
+        project = Xcodeproj::Project.open(params[:xcodeproj])
+        configs = project.objects.select { |obj| select_build_configuration_predicate(nil, obj) }
+        configs.first.build_settings["CURRENT_PROJECT_VERSION"]
+      end
+
+      private_class_method
+      def self.select_build_configuration_predicate(name, configuration)
+        is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.build_settings["PRODUCT_BUNDLE_IDENTIFIER"].nil?
+        is_build_valid_configuration &&= configuration.name == name unless name.nil?
+        return is_build_valid_configuration
+      end
+
+      def self.get_build_number_using_target(params)
+        project = Xcodeproj::Project.open(params[:xcodeproj])
+        if params[:target]
+          target = project.targets.detect { |t| t.name == params[:target] }
+        else
+          # firstly we are trying to find modern application target
+          target = project.targets.detect do |t|
+            t.kind_of?(Xcodeproj::Project::Object::PBXNativeTarget) &&
+              t.product_type == 'com.apple.product-type.application'
           end
+          target = project.targets[0] if target.nil?
+        end
 
-          build_number = target.resolved_build_setting('CURRENT_PROJECT_VERSION', true)
-          UI.user_error! 'Cannot resolve build number build setting.' if build_number.nil? || build_number.empty? #TODO: come back to this message
-  
-          if !(build_configuration_name = params[:build_configuration_name]).nil?
-            build_number = build_number[build_configuration_name]
-            UI.user_error! "Cannot resolve CURRENT_PROJECT_VERSION build setting for #{build_configuration_name}." if plist.nil?
-          else
-            build_number = build_number.values.compact.uniq
-            UI.user_error! 'Cannot accurately resolve CURRENT_PROJECT_VERSION build setting, try specifying :build_configuration_name.' if build_number.count > 1
-            build_number = build_number.first
-          end
+        build_number = target.resolved_build_setting('CURRENT_PROJECT_VERSION', true)
+        UI.user_error! 'Cannot resolve build number build setting.' if build_number.nil? || build_number.empty? # TODO: come back to this message
 
-          build_number
+        if !(build_configuration_name = params[:build_configuration_name]).nil?
+          build_number = build_number[build_configuration_name]
+          UI.user_error! "Cannot resolve CURRENT_PROJECT_VERSION build setting for #{build_configuration_name}." if plist.nil?
+        else
+          build_number = build_number.values.compact.uniq
+          UI.user_error! 'Cannot accurately resolve CURRENT_PROJECT_VERSION build setting, try specifying :build_configuration_name.' if build_number.count > 1
+          build_number = build_number.first
         end
-  
-        def self.get_build_number_using_scheme(params)
-          config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
-          project = FastlaneCore::Project.new(config)
-          project.select_scheme
-  
-          build_number = project.build_settings(key: 'CURRENT_PROJECT_VERSION')
-          #TODO: USER_ERROR message same as in line 38?
-          build_number
-        end
-  
-        #####################################################
-        # @!group Documentation
-        #####################################################
-  
-        def self.description
-          "Get the version number of your project"
-        end
-  
-        def self.details
-          'TODO:'
-        end
-  
-        def self.available_options
-          [
-            FastlaneCore::ConfigItem.new(key: :xcodeproj,
-                                         env_name: "FL_BUILD_NUMBER_PROJECT",
-                                         description: "Optional, you must specify the path to your main Xcode project if it is not in the project root directory or if you have multiple *.xcodeproj's in the root directory",
-                                         optional: true,
-                                         verify_block: proc do |value|
-                                           UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
-                                           UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
-                                         end),
-            FastlaneCore::ConfigItem.new(key: :target,
-                                         env_name: "FL_BUILD_NUMBER_TARGET",
-                                         optional: true,
-                                         conflicting_options: [:scheme],
-                                         description: "Specify a specific target if you have multiple per project, optional"),
-            FastlaneCore::ConfigItem.new(key: :scheme,
-                                         env_name: "FL_BUILD_NUMBER_SCHEME",
-                                         optional: true,
-                                         conflicting_options: [:target],
-                                         description: "Specify a specific scheme if you have multiple per project, optional"),
-            FastlaneCore::ConfigItem.new(key: :build_configuration_name,
-                                         optional: true,
-                                         description: "Specify a specific build configuration if you have different build settings for each configuration")
-  
-          ]
-        end
-  
-        def self.authors
-          ["jdouglas-nz"]
-        end
-  
-        def self.is_supported?(platform)
-          [:ios, :mac].include? platform
-        end
+
+        build_number
+      end
+
+      def self.get_build_number_using_scheme(params)
+        config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
+        project = FastlaneCore::Project.new(config)
+        project.select_scheme
+
+        build_number = project.build_settings(key: 'CURRENT_PROJECT_VERSION')
+        # TODO: USER_ERROR message same as in line 38?
+        build_number
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Get the version number of your project"
+      end
+
+      def self.details
+        'TODO:'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                       env_name: "FL_BUILD_NUMBER_PROJECT",
+                                       description: "Optional, you must specify the path to your main Xcode project if it is not in the project root directory or if you have multiple *.xcodeproj's in the root directory",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                                         UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :target,
+                                       env_name: "FL_BUILD_NUMBER_TARGET",
+                                       optional: true,
+                                       conflicting_options: [:scheme],
+                                       description: "Specify a specific target if you have multiple per project, optional"),
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                                       env_name: "FL_BUILD_NUMBER_SCHEME",
+                                       optional: true,
+                                       conflicting_options: [:target],
+                                       description: "Specify a specific scheme if you have multiple per project, optional"),
+          FastlaneCore::ConfigItem.new(key: :build_configuration_name,
+                                       optional: true,
+                                       description: "Specify a specific build configuration if you have different build settings for each configuration")
+
+        ]
+      end
+
+      def self.authors
+        ["jdouglas-nz"]
+      end
+
+      def self.is_supported?(platform)
+        %i[ios mac].include? platform
       end
     end
   end
-  
+  end

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
@@ -1,0 +1,113 @@
+module Fastlane
+    module Actions
+      class GetBuildNumberFromXcodeprojAction < Action
+        require 'xcodeproj'
+        require 'pathname'
+  
+        def self.run(params)
+          unless params[:xcodeproj]
+            if Helper.test?
+              params[:xcodeproj] = "/tmp/fastlane/tests/fastlane/xcodeproj/versioning_fixture_project.xcodeproj"
+            else
+              params[:xcodeproj] = Dir["*.xcodeproj"][0] unless params[:xcodeproj]
+            end
+          end
+  
+          if params[:target]
+            build_number = get_build_number_using_target(params)
+          else
+            build_number = get_build_number_using_scheme(params)
+          end
+
+          Actions.lane_context[SharedValues::BUILD_NUMBER] = build_number #TODO: compared to ths plist getter, this is a slightly different meaning. BUILD_NUMBER is like <major>.<minor>.<patch>.<build> as opposed to <build>
+          build_number
+        end
+  
+        def self.get_build_number_using_target(params)
+          project = Xcodeproj::Project.open(params[:xcodeproj])
+          if params[:target]
+            target = project.targets.detect { |t| t.name == params[:target] }
+          else
+            # firstly we are trying to find modern application target
+            target = project.targets.detect do |t|
+              t.kind_of?(Xcodeproj::Project::Object::PBXNativeTarget) &&
+                t.product_type == 'com.apple.product-type.application'
+            end
+            target = project.targets[0] if target.nil?
+          end
+
+          build_number = target.resolved_build_setting('CURRENT_PROJECT_VERSION', true)
+          UI.user_error! 'Cannot resolve build number build setting.' if build_number.nil? || build_number.empty? #TODO: come back to this message
+  
+          if !(build_configuration_name = params[:build_configuration_name]).nil?
+            build_number = build_number[build_configuration_name]
+            UI.user_error! "Cannot resolve CURRENT_PROJECT_VERSION build setting for #{build_configuration_name}." if plist.nil?
+          else
+            build_number = build_number.values.compact.uniq
+            UI.user_error! 'Cannot accurately resolve CURRENT_PROJECT_VERSION build setting, try specifying :build_configuration_name.' if build_number.count > 1
+            build_number = build_number.first
+          end
+
+          build_number
+        end
+  
+        def self.get_build_number_using_scheme(params)
+          config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
+          project = FastlaneCore::Project.new(config)
+          project.select_scheme
+  
+          build_number = project.build_settings(key: 'CURRENT_PROJECT_VERSION')
+          #TODO: USER_ERROR message same as in line 38?
+          build_number
+        end
+  
+        #####################################################
+        # @!group Documentation
+        #####################################################
+  
+        def self.description
+          "Get the version number of your project"
+        end
+  
+        def self.details
+          'TODO:'
+        end
+  
+        def self.available_options
+          [
+            FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                         env_name: "FL_BUILD_NUMBER_PROJECT",
+                                         description: "Optional, you must specify the path to your main Xcode project if it is not in the project root directory or if you have multiple *.xcodeproj's in the root directory",
+                                         optional: true,
+                                         verify_block: proc do |value|
+                                           UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                                           UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
+                                         end),
+            FastlaneCore::ConfigItem.new(key: :target,
+                                         env_name: "FL_BUILD_NUMBER_TARGET",
+                                         optional: true,
+                                         conflicting_options: [:scheme],
+                                         description: "Specify a specific target if you have multiple per project, optional"),
+            FastlaneCore::ConfigItem.new(key: :scheme,
+                                         env_name: "FL_BUILD_NUMBER_SCHEME",
+                                         optional: true,
+                                         conflicting_options: [:target],
+                                         description: "Specify a specific scheme if you have multiple per project, optional"),
+            FastlaneCore::ConfigItem.new(key: :build_configuration_name,
+                                         optional: true,
+                                         description: "Specify a specific build configuration if you have different build settings for each configuration")
+  
+          ]
+        end
+  
+        def self.authors
+          ["jdouglas-nz"]
+        end
+  
+        def self.is_supported?(platform)
+          [:ios, :mac].include? platform
+        end
+      end
+    end
+  end
+  

--- a/lib/fastlane/plugin/versioning/actions/get_info_plist_path.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_info_plist_path.rb
@@ -7,7 +7,7 @@ module Fastlane
       def self.run(params)
         unless params[:xcodeproj]
           if Helper.test?
-            params[:xcodeproj] = "/tmp/fastlane/tests/fastlane/bundle.xcodeproj"
+            params[:xcodeproj] = "/tmp/fastlane/tests/fastlane/xcodeproj/bundle.xcodeproj"
           else
             params[:xcodeproj] = Dir["*.xcodeproj"][0] unless params[:xcodeproj]
           end

--- a/lib/fastlane/plugin/versioning/actions/get_info_plist_path.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_info_plist_path.rb
@@ -99,7 +99,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                                        optional: true,
                                        description: "Specify a specific build configuration if you have different Info.plist build settings for each configuration")
-
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_info_plist_path.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_info_plist_path.rb
@@ -108,7 +108,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform
+        %i[ios mac].include? platform
       end
     end
   end

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_git_branch.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_git_branch.rb
@@ -39,7 +39,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac, :android].include? platform
+        %i[ios mac android].include? platform
       end
     end
   end

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
@@ -8,9 +8,17 @@ module Fastlane
           plist = GetInfoPlistPathAction.run(params)
         end
 
-        version_number = GetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString')
+        if params[:plist_build_setting_support]
+          UI.important "Version will originate from xcodeproj"
+          version_number = GetVersionNumberFromXcodeprojAction.run(params)
+        else
+          UI.important "Version will originate from plist."
+          version_number = GetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString')
+        end
+
         # Store the number in the shared hash
         Actions.lane_context[SharedValues::VERSION_NUMBER] = version_number
+        version_number
       end
 
       #####################################################
@@ -49,7 +57,11 @@ module Fastlane
                              description: "Specify a specific scheme if you have multiple per project, optional"),
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                              optional: true,
-                             description: "Specify a specific build configuration if you have different Info.plist build settings for each configuration")
+                             description: "Specify a specific build configuration if you have different Info.plist build settings for each configuration"),
+          FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
+                            description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
+                            is_string: false,
+                            default_value: false) #TODO: for backwards compatibility, should eventually turn to true?
 
         ]
       end

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
@@ -1,4 +1,4 @@
-module Fastlane
+ module Fastlane
   module Actions
     class GetVersionNumberFromPlistAction < Action
       def self.run(params)
@@ -65,7 +65,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                             description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                             is_string: false,
-                            default_value: false) #TODO: for backwards compatibility, should eventually turn to true?
+                            default_value: false) # TODO: for backwards compatibility, should eventually turn to true?
 
         ]
       end
@@ -81,7 +81,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform
+        %i[ios mac].include? platform
       end
     end
   end

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
@@ -9,10 +9,10 @@
         end
 
         if params[:plist_build_setting_support]
-          UI.important "Version will originate from xcodeproj"
+          UI.important "version will originate from xcodeproj"
           version_number = GetVersionNumberFromXcodeprojAction.run(params)
         else
-          UI.important "Version will originate from plist."
+          UI.important "version will originate from plist."
           version_number = GetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString')
         end
 

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
@@ -73,7 +73,7 @@
       end
 
       def self.authors
-        ["SiarheiFedartsou"]
+        ["SiarheiFedartsou", "jdouglas-nz"]
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
@@ -14,10 +14,6 @@
         else
           UI.important "Version will originate from plist."
           version_number = GetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString')
-          if version_number =~ /\$\(([\w\-]+)\)/
-            UI.important "info plist value is a build setting. will now resolve from xcodeproject."
-            version_number = GetBuildNumberFromXcodeprojAction.run(params)
-          end
         end
 
         # Store the number in the shared hash
@@ -35,7 +31,8 @@
 
       def self.details
         [
-          "This action will return the current version number set on your project's Info.plist."
+          "This action will return the current version number set on your project's Info.plist.",
+          "note that you can pass plist_build_setting_support: true, in which case it will return from your xcodeproj."
         ].join(' ')
       end
 
@@ -65,8 +62,7 @@
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                             description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                             is_string: false,
-                            default_value: false) # TODO: for backwards compatibility, should eventually turn to true?
-
+                            default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
@@ -14,6 +14,10 @@ module Fastlane
         else
           UI.important "Version will originate from plist."
           version_number = GetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString')
+          if version_number =~ /\$\(([\w\-]+)\)/
+            UI.important "info plist value is a build setting. will now resolve from xcodeproject."
+            version_number = GetBuildNumberFromXcodeprojAction.run(params)
+          end
         end
 
         # Store the number in the shared hash

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
@@ -3,7 +3,7 @@
     class GetVersionNumberFromPlistAction < Action
       def self.run(params)
         if Helper.test?
-          plist = "/tmp/fastlane/tests/fastlane/Info.plist"
+          plist = "/tmp/fastlane/tests/fastlane/plist/Info.plist"
         else
           plist = GetInfoPlistPathAction.run(params)
         end

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
@@ -1,0 +1,112 @@
+module Fastlane
+  module Actions
+    class GetVersionNumberFromXcodeprojAction < Action
+      require 'xcodeproj'
+      require 'pathname'
+
+      def self.run(params)
+        unless params[:xcodeproj]
+          if Helper.test?
+            params[:xcodeproj] = "/tmp/fastlane/tests/fastlane/xcodeproj/versioning_fixture_project.xcodeproj"
+          else
+            params[:xcodeproj] = Dir["*.xcodeproj"][0] unless params[:xcodeproj]
+          end
+        end
+
+        if params[:target]
+          version_number = get_version_number_using_target(params)
+        else
+          version_number = get_version_number_using_scheme(params)
+        end
+
+        Actions.lane_context[SharedValues::VERSION_NUMBER] = version_number
+        version_number
+      end
+
+      def self.get_version_number_using_target(params)
+        project = Xcodeproj::Project.open(params[:xcodeproj])
+        if params[:target]
+          target = project.targets.detect { |t| t.name == params[:target] }
+        else
+          # firstly we are trying to find modern application target
+          target = project.targets.detect do |t|
+            t.kind_of?(Xcodeproj::Project::Object::PBXNativeTarget) &&
+              t.product_type == 'com.apple.product-type.application'
+          end
+          target = project.targets[0] if target.nil?
+        end
+
+        version_number = target.resolved_build_setting('MARKETING_VERSION', true)
+        UI.user_error! 'Cannot resolve build number build setting.' if version_number.nil? || version_number.empty? #TODO: come back to this message
+
+        if !(build_configuration_name = params[:build_configuration_name]).nil?
+          version_number = version_number[build_configuration_name]
+          UI.user_error! "Cannot resolve MARKETING_VERSION build setting for #{build_configuration_name}." if plist.nil?
+        else
+          version_number = version_number.values.compact.uniq
+          UI.user_error! 'Cannot accurately resolve MARKETING_VERSION build setting, try specifying :build_configuration_name.' if version_number.count > 1
+          version_number = version_number.first
+        end
+
+        version_number
+      end
+
+      def self.get_version_number_using_scheme(params)
+        config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
+        project = FastlaneCore::Project.new(config)
+        project.select_scheme
+
+        build_number = project.build_settings(key: 'MARKETING_VERSION')
+        #TODO: USER_ERROR message same as in line 38?
+        build_number
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Get the version number of your project"
+      end
+
+      def self.details
+        'TODO:'
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                       env_name: "FL_VERSION_NUMBER_PROJECT",
+                                       description: "Optional, you must specify the path to your main Xcode project if it is not in the project root directory or if you have multiple *.xcodeproj's in the root directory",
+                                       optional: true,
+                                       verify_block: proc do |value|
+                                         UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                                         UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
+                                       end),
+          FastlaneCore::ConfigItem.new(key: :target,
+                                       env_name: "FL_VERSION_NUMBER_TARGET",
+                                       optional: true,
+                                       conflicting_options: [:scheme],
+                                       description: "Specify a specific target if you have multiple per project, optional"),
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                                       env_name: "FL_VERSION_NUMBER_SCHEME",
+                                       optional: true,
+                                       conflicting_options: [:target],
+                                       description: "Specify a specific scheme if you have multiple per project, optional"),
+          FastlaneCore::ConfigItem.new(key: :build_configuration_name,
+                                       optional: true,
+                                       description: "Specify a specific build configuration if you have different build settings for each configuration")
+
+        ]
+      end
+
+      def self.authors
+        ["jdouglas-nz"]
+      end
+
+      def self.is_supported?(platform)
+        [:ios, :mac].include? platform
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
@@ -37,14 +37,14 @@ module Fastlane
         end
 
         version_number = target.resolved_build_setting('MARKETING_VERSION', true)
-        UI.user_error! 'Cannot resolve build number build setting.' if version_number.nil? || version_number.empty? # TODO: come back to this message
+        UI.user_error! 'Cannot resolve version number build setting.' if version_number.nil? || version_number.empty?
 
         if !(build_configuration_name = params[:build_configuration_name]).nil?
           version_number = version_number[build_configuration_name]
-          UI.user_error! "Cannot resolve MARKETING_VERSION build setting for #{build_configuration_name}." if plist.nil?
+          UI.user_error! "Cannot resolve $(MARKETING_VERSION) build setting for #{build_configuration_name}." if plist.nil?
         else
           version_number = version_number.values.compact.uniq
-          UI.user_error! 'Cannot accurately resolve MARKETING_VERSION build setting, try specifying :build_configuration_name.' if version_number.count > 1
+          UI.user_error! 'Cannot accurately resolve $(MARKETING_VERSION) build setting, try specifying :build_configuration_name.' if version_number.count > 1
           version_number = version_number.first
         end
 

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
@@ -57,7 +57,7 @@ module Fastlane
         project.select_scheme
 
         build_number = project.build_settings(key: 'MARKETING_VERSION')
-        # TODO: USER_ERROR message same as in line 38?
+        UI.user_error! "Cannot resolve $(MARKETING_VERSION) in for the scheme #{config.scheme} with the name #{params.configuration}" if build_number.nil? || build_number.empty?
         build_number
       end
 
@@ -70,7 +70,7 @@ module Fastlane
       end
 
       def self.details
-        'TODO:'
+        'Gets the $(MARKETING_VERSION) build setting using the specified parameters, or the first if not enough parameters are passed.'
       end
 
       def self.available_options
@@ -96,7 +96,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                                        optional: true,
                                        description: "Specify a specific build configuration if you have different build settings for each configuration")
-
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
@@ -37,7 +37,7 @@ module Fastlane
         end
 
         version_number = target.resolved_build_setting('MARKETING_VERSION', true)
-        UI.user_error! 'Cannot resolve build number build setting.' if version_number.nil? || version_number.empty? #TODO: come back to this message
+        UI.user_error! 'Cannot resolve build number build setting.' if version_number.nil? || version_number.empty? # TODO: come back to this message
 
         if !(build_configuration_name = params[:build_configuration_name]).nil?
           version_number = version_number[build_configuration_name]
@@ -57,7 +57,7 @@ module Fastlane
         project.select_scheme
 
         build_number = project.build_settings(key: 'MARKETING_VERSION')
-        #TODO: USER_ERROR message same as in line 38?
+        # TODO: USER_ERROR message same as in line 38?
         build_number
       end
 
@@ -105,7 +105,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform
+        %i[ios mac].include? platform
       end
     end
   end

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
@@ -21,7 +21,7 @@ module Fastlane
         if build_number =~ /\$\(([\w\-]+)\)/
           UI.important "detected that build number is a build setting."
           if params[:plist_build_setting_support]
-            UI.important "will continue and update the xcodeproj CURRENT_PROJECT_VERSION instead."
+            UI.important "will continue and update the xcodeproj $(CURRENT_PROJECT_VERSION) instead."
             IncrementBuildNumberInXcodeprojAction.run(params)
           else
             UI.important "will continue and update the info plist key. this will replace the existing value."
@@ -29,7 +29,7 @@ module Fastlane
           end
         else
           if params[:plist_build_setting_support]
-            UI.important "will continue and update the xcodeproj CURRENT_PROJECT_VERSION instead."
+            UI.important "will continue and update the xcodeproj $(CURRENT_PROJECT_VERSION) instead."
             IncrementBuildNumberInXcodeprojAction.run(params)
             UI.important "will also update info plist key to be a build setting"
             SetInfoPlistValueAction.run(path: plist, key: 'CFBundleVersion', value: "$(CURRENT_PROJECT_VERSION)")

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
@@ -95,7 +95,7 @@ module Fastlane
       end
 
       def self.authors
-        ["SiarheiFedartsou", "jdouglas-nz"
+        ["SiarheiFedartsou", "jdouglas-nz"]
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
@@ -22,7 +22,7 @@ module Fastlane
           UI.important "detected that build number is a build setting."
           if params[:plist_build_setting_support]
             UI.important "will continue and update the xcodeproj CURRENT_PROJECT_VERSION instead."
-            IncrementBuildNumberInXcodeProjAction.run(params) #TODO: implement me.
+            IncrementBuildNumberInXcodeprojAction.run(params)
           else
             UI.important "will continue and update the info plist key. this will replace the existing value."
             SetInfoPlistValueAction.run(path: plist, key: 'CFBundleVersion', value: next_build_number)

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
@@ -94,8 +94,8 @@ module Fastlane
         ]
       end
 
-      def self.author
-        "SiarheiFedartsou"
+      def self.authors
+        ["SiarheiFedartsou", "jdouglas-nz"
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
@@ -40,6 +40,7 @@ module Fastlane
         end
 
         Actions.lane_context[SharedValues::BUILD_NUMBER] = next_build_number
+        next_build_number
       end
 
       def self.description
@@ -83,7 +84,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                                         description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                                         is_string: false,
-                                        default_value: false) # TODO: for backwards compatibility, should eventually turn to true?
+                                        default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
@@ -12,7 +12,7 @@ module Fastlane
         end
 
         if Helper.test?
-          plist = "/tmp/fastlane/tests/fastlane/Info.plist"
+          plist = "/tmp/fastlane/tests/fastlane/plist/Info.plist"
         else
           plist = GetInfoPlistPathAction.run(params)
         end

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
@@ -107,7 +107,6 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                                          optional: true,
                                          description: "Specify a specific build configuration if you have different build settings for each configuration")
-
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
@@ -1,4 +1,3 @@
-
 module Fastlane
   module Actions
     class IncrementBuildNumberInXcodeprojAction < Action
@@ -16,7 +15,7 @@ module Fastlane
         else
           current_build_number = GetBuildNumberFromXcodeprojAction.run(params)
           build_array = current_build_number.split(".").map(&:to_i)
-          build_array[-1] = build_array[-1]+1            
+          build_array[-1] = build_array[-1] + 1
           next_build_number = build_array.join(".")
         end
 
@@ -24,7 +23,7 @@ module Fastlane
           set_build_number_using_target(params, next_build_number)
         elsif params[:build_configuration_name] && params[:scheme]
           set_build_number_using_scheme(params, next_build_number)
-        else 
+        else
           set_all_xcodeproj_build_numbers(params, next_build_number)
         end
         Actions.lane_context[SharedValues::BUILD_NUMBER] = next_build_number
@@ -69,7 +68,7 @@ module Fastlane
         project = FastlaneCore::Project.new(config)
         project.select_scheme
 
-        project.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number 
+        project.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number
         project.save
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
@@ -1,0 +1,124 @@
+
+module Fastlane
+  module Actions
+    class IncrementBuildNumberInXcodeprojAction < Action
+      def self.run(params)
+        unless params[:xcodeproj]
+          if Helper.test?
+            params[:xcodeproj] = "/tmp/fastlane/tests/fastlane/xcodeproj/versioning_fixture_project.xcodeproj"
+          else
+            params[:xcodeproj] = Dir["*.xcodeproj"][0] unless params[:xcodeproj]
+          end
+        end
+
+        if params[:build_number]
+          next_build_number = params[:build_number]
+        else
+          current_build_number = GetBuildNumberFromXcodeprojAction.run(params)
+          build_array = current_build_number.split(".").map(&:to_i)
+          build_array[-1] = build_array[-1]+1            
+          next_build_number = build_array.join(".")
+        end
+
+        if params[:target]
+          set_build_number_using_target(params, next_build_number)
+        elsif params[:build_configuration_name] && params[:scheme]
+          set_build_number_using_scheme(params, next_build_number)
+        else 
+          set_all_xcodeproj_build_numbers(params, next_build_number)
+        end
+        Actions.lane_context[SharedValues::BUILD_NUMBER] = next_build_number
+        next_build_number
+      end
+
+      def self.set_all_xcodeproj_build_numbers(params, next_build_number)
+        project = Xcodeproj::Project.open(params[:xcodeproj])
+        configs = project.objects.select { |obj| select_build_configuration_predicate(nil, obj) }
+        configs.each do |config|
+          config.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number
+        end
+        project.save
+      end
+
+      private_class_method
+      def self.select_build_configuration_predicate(name, configuration)
+        is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.build_settings["PRODUCT_BUNDLE_IDENTIFIER"].nil?
+        is_build_valid_configuration &&= configuration.name == name unless name.nil?
+        return is_build_valid_configuration
+      end
+
+      def self.set_build_number_using_target(params, next_build_number)
+        project = Xcodeproj::Project.open(params[:xcodeproj])
+        if params[:target]
+          target = project.targets.detect { |t| t.name == params[:target] }
+        else
+          # firstly we are trying to find modern application target
+          target = project.targets.detect do |t|
+            t.kind_of?(Xcodeproj::Project::Object::PBXNativeTarget) &&
+              t.product_type == 'com.apple.product-type.application'
+          end
+          target = project.targets[0] if target.nil?
+        end
+
+        project.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number
+        project.save
+      end
+
+      def self.set_build_number_using_scheme(params, next_build_number)
+        config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
+        project = FastlaneCore::Project.new(config)
+        project.select_scheme
+
+        project.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number 
+        project.save
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Increment build number in xcodeproj"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :build_number,
+                                      env_name: "FL_BUILD_NUMBER_BUILD_NUMBER",
+                                      description: "Change to a specific build number",
+                                      optional: true),
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                                         env_name: "FL_VERSION_NUMBER_PROJECT",
+                                         description: "Optional, you must specify the path to your main Xcode project if it is not in the project root directory or if you have multiple *.xcodeproj's in the root directory",
+                                         optional: true,
+                                         verify_block: proc do |value|
+                                           UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                                           UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
+                                         end),
+          FastlaneCore::ConfigItem.new(key: :target,
+                                         env_name: "FL_VERSION_NUMBER_TARGET",
+                                         optional: true,
+                                         conflicting_options: [:scheme],
+                                         description: "Specify a specific target if you have multiple per project, optional"),
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                                         env_name: "FL_VERSION_NUMBER_SCHEME",
+                                         optional: true,
+                                         conflicting_options: [:target],
+                                         description: "Specify a specific scheme if you have multiple per project, optional"),
+          FastlaneCore::ConfigItem.new(key: :build_configuration_name,
+                                         optional: true,
+                                         description: "Specify a specific build configuration if you have different build settings for each configuration")
+
+        ]
+      end
+
+      def self.authors
+        ["jdouglas-nz"]
+      end
+
+      def self.is_supported?(platform)
+        %i[ios mac android].include? platform
+      end
+    end
+  end
+  end

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
@@ -38,9 +38,22 @@ module Fastlane
           plist = GetInfoPlistPathAction.run(params)
         end
 
-        SetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString', value: next_version_number)
+        if current_version =~ /\$\(([\w\-]+)\)/
+          UI.important "detected that build number is a build setting."
+          if params[:plist_build_setting_support]
+            UI.important "will continue and update the xcodeproj CURRENT_PROJECT_VERSION instead."
+            IncrementVersionNumberInXcodeprojAction.run(params)
+          else
+            UI.important "will continue and update the info plist key. this will replace the existing value."
+            SetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString', value: next_version_number)
+          end
+        else
+          UI.important "setting plist build version"
+          SetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString', value: next_version_number)
+        end
 
         Actions.lane_context[SharedValues::VERSION_NUMBER] = next_version_number
+        next_version_number
       end
 
       def self.description

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
@@ -107,7 +107,12 @@ module Fastlane
                                        verify_block: proc do |value|
                                          UI.user_error!("Available values are 'plist' and 'appstore'") unless ['plist', 'appstore'].include? value
                                        end,
-                                       description: "Source version to increment. Available options: plist, appstore")
+                                       description: "Source version to increment. Available options: plist, appstore"),
+          FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
+                                        description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
+                                        is_string: false,
+                                        default_value: false) #TODO: for backwards compatibility, should eventually turn to true?
+            
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
@@ -33,7 +33,7 @@ module Fastlane
         end
 
         if Helper.test?
-          plist = "/tmp/fastlane/tests/fastlane/Info.plist"
+          plist = "/tmp/fastlane/tests/fastlane/plist/Info.plist"
         else
           plist = GetInfoPlistPathAction.run(params)
         end

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
@@ -15,18 +15,18 @@ module Fastlane
           version_array = current_version.split(".").map(&:to_i)
           case params[:bump_type]
           when "patch"
-            version_array[2] = (version_array[2] ? version_array[2] : 0) + 1
+            version_array[2] = (version_array[2] || 0) + 1
           when "minor"
-            version_array[1] = (version_array[1] ? version_array[1] : 0) + 1
+            version_array[1] = (version_array[1] || 0) + 1
             version_array[2] = version_array[2] = 0
           when "major"
-            version_array[0] = (version_array[0] ? version_array[0] : 0) + 1
+            version_array[0] = (version_array[0] || 0) + 1
             version_array[1] = version_array[1] = 0
             version_array[1] = version_array[2] = 0
           end
 
           if params[:omit_zero_patch_version] && version_array[2] == 0
-            version_array.pop()
+            version_array.pop
           end
 
           next_version_number = version_array.join(".")
@@ -51,6 +51,8 @@ module Fastlane
           if params[:plist_build_setting_support]
             UI.important "will update the xcodeproj MARKETING_VERSION."
             IncrementVersionNumberInXcodeprojAction.run(params)
+            UI.important "will also update info plist key to be a build setting"
+            SetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString', value: "$(MARKETING_VERSION)")
           else
             UI.important "will update the info plist key. this will replace the existing value."
             SetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString', value: next_version_number)
@@ -94,7 +96,7 @@ module Fastlane
                                        env_name: "FL_APPSTORE_VERSION_NUMBER_BUNDLE_ID",
                                        description: "Bundle ID of the application",
                                        optional: true,
-                                       conflicting_options: [:xcodeproj, :target, :build_configuration_name, :scheme],
+                                       conflicting_options: %i[xcodeproj target build_configuration_name scheme],
                                        is_string: true),
           FastlaneCore::ConfigItem.new(key: :xcodeproj,
                                        env_name: "FL_VERSION_NUMBER_PROJECT",
@@ -108,12 +110,12 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :target,
                                        env_name: "FL_VERSION_NUMBER_TARGET",
                                        optional: true,
-                                       conflicting_options: [:bundle_id, :scheme],
+                                       conflicting_options: %i[bundle_id scheme],
                                        description: "Specify a specific target if you have multiple per project, optional"),
           FastlaneCore::ConfigItem.new(key: :scheme,
                                        env_name: "FL_VERSION_NUMBER_SCHEME",
                                        optional: true,
-                                       conflicting_options: [:bundle_id, :target],
+                                       conflicting_options: %i[bundle_id target],
                                        description: "Specify a specific scheme if you have multiple per project, optional"),
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                                        optional: true,
@@ -129,8 +131,8 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                                         description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                                         is_string: false,
-                                        default_value: false) #TODO: for backwards compatibility, should eventually turn to true?
-            
+                                        default_value: false) # TODO: for backwards compatibility, should eventually turn to true?
+
         ]
       end
 
@@ -145,7 +147,7 @@ module Fastlane
       end
 
       def self.is_supported?(platform)
-        [:ios, :mac].include? platform
+        %i[ios mac].include? platform
       end
     end
   end

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
@@ -142,8 +142,8 @@ module Fastlane
         ]
       end
 
-      def self.author
-        "SiarheiFedartsou"
+      def self.authors
+        ["SiarheiFedartsou", "jdouglas-nz"]
       end
 
       def self.is_supported?(platform)

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
@@ -69,7 +69,8 @@ module Fastlane
 
       def self.details
         [
-          "This action will increment the version number directly in Info.plist. "
+          "This action will increment the version number directly in Info.plist. ",
+          "unless plist_build_setting_support: true is passed in as parameters"
         ].join("\n")
       end
 
@@ -131,8 +132,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                                         description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                                         is_string: false,
-                                        default_value: false) # TODO: for backwards compatibility, should eventually turn to true?
-
+                                        default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
@@ -39,17 +39,22 @@ module Fastlane
         end
 
         if current_version =~ /\$\(([\w\-]+)\)/
-          UI.important "detected that build number is a build setting."
+          UI.important "detected that version is a build setting."
           if params[:plist_build_setting_support]
-            UI.important "will continue and update the xcodeproj CURRENT_PROJECT_VERSION instead."
+            UI.important "will continue and update the xcodeproj MARKETING_VERSION instead."
             IncrementVersionNumberInXcodeprojAction.run(params)
           else
             UI.important "will continue and update the info plist key. this will replace the existing value."
             SetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString', value: next_version_number)
           end
         else
-          UI.important "setting plist build version"
-          SetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString', value: next_version_number)
+          if params[:plist_build_setting_support]
+            UI.important "will update the xcodeproj MARKETING_VERSION."
+            IncrementVersionNumberInXcodeprojAction.run(params)
+          else
+            UI.important "will update the info plist key. this will replace the existing value."
+            SetInfoPlistValueAction.run(path: plist, key: 'CFBundleShortVersionString', value: next_version_number)
+          end
         end
 
         Actions.lane_context[SharedValues::VERSION_NUMBER] = next_version_number

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
@@ -6,9 +6,8 @@ module Fastlane
           next_version_number = params[:version_number]
         else
           case params[:version_source]
-          when "plist"
-            params[:plist_build_setting_support] = true
-            current_version = GetVersionNumberFromPlistAction.run(params)
+          when "xcodeproj"
+            current_version = GetVersionNumberFromXcodeprojAction.run(params)
           when "appstore"
             current_version = GetAppStoreVersionNumberAction.run(params)
           end
@@ -148,14 +147,14 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                         optional: true,
                         conflicting_options: [:bundle_id],
-                        description: "Specify a specific build configuration if you have different Info.plist build settings for each configuration"),
+                        description: "Specify a specific build configuration if you have different build settings for each configuration"),
           FastlaneCore::ConfigItem.new(key: :version_source,
                         optional: true,
-                        default_value: 'plist',
+                        default_value: 'xcodeproj',
                         verify_block: proc do |value|
-                          UI.user_error!("Available values are 'plist' and 'appstore'") unless ['plist', 'appstore'].include? value
+                          UI.user_error!("Available values are 'xcodeproj' and 'appstore'") unless ['xcodeproj', 'appstore'].include? value
                         end,
-                        description: "Source version to increment. Available options: plist, appstore"),
+                        description: "Source version to increment. Available options: xcodeproj, appstore"),
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                          description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                          is_string: false,

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
@@ -154,7 +154,11 @@ module Fastlane
                         verify_block: proc do |value|
                           UI.user_error!("Available values are 'xcodeproj' and 'appstore'") unless ['xcodeproj', 'appstore'].include? value
                         end,
-                        description: "Source version to increment. Available options: xcodeproj, appstore")
+                        description: "Source version to increment. Available options: xcodeproj, appstore"),
+          FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
+                         description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
+                         is_string: false,
+                         default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
@@ -154,12 +154,7 @@ module Fastlane
                         verify_block: proc do |value|
                           UI.user_error!("Available values are 'xcodeproj' and 'appstore'") unless ['xcodeproj', 'appstore'].include? value
                         end,
-                        description: "Source version to increment. Available options: xcodeproj, appstore"),
-          FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
-                         description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
-                         is_string: false,
-                         default_value: false) # TODO: for backwards compatibility, should eventually turn to true?
-
+                        description: "Source version to increment. Available options: xcodeproj, appstore")
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
@@ -1,0 +1,176 @@
+module Fastlane
+  module Actions
+    class IncrementVersionNumberInXcodeprojAction < Action
+      def self.run(params)
+        if params[:version_number]
+          next_version_number = params[:version_number]
+        else
+          case params[:version_source]
+          when "plist"
+            params[:plist_build_setting_support] = true
+            current_version = GetVersionNumberFromPlistAction.run(params)
+          when "appstore"
+            current_version = GetAppStoreVersionNumberAction.run(params)
+          end
+
+          version_array = current_version.split(".").map(&:to_i)
+          case params[:bump_type]
+          when "patch"
+            version_array[2] = (version_array[2] || 0) + 1
+          when "minor"
+            version_array[1] = (version_array[1] || 0) + 1
+            version_array[2] = version_array[2] = 0
+          when "major"
+            version_array[0] = (version_array[0] || 0) + 1
+            version_array[1] = version_array[1] = 0
+            version_array[1] = version_array[2] = 0
+          end
+
+          if params[:omit_zero_patch_version] && version_array[2] == 0
+            version_array.pop
+          end
+
+          next_version_number = version_array.join(".")
+          end
+
+        if Helper.test?
+          params[:xcodeproj] = "/tmp/fastlane/tests/fastlane/xcodeproj/versioning_fixture_project.xcodeproj"
+        else
+          params[:xcodeproj] = Dir["*.xcodeproj"][0] unless params[:xcodeproj]
+        end
+
+        if params[:target]
+          set_version_number_using_target(params, next_version_number)
+        elsif params[:build_configuration_name] && params[:scheme]
+          set_version_number_using_scheme(params, next_version_number)
+        else
+          set_all_xcodeproj_version_numbers(params, next_version_number)
+        end
+
+        Actions.lane_context[SharedValues::VERSION_NUMBER] = next_version_number
+        next_version_number
+      end
+
+      def self.set_all_xcodeproj_version_numbers(params, next_version_number)
+        project = Xcodeproj::Project.open(params[:xcodeproj])
+        configs = project.objects.select { |obj| select_build_configuration_predicate(nil, obj) }
+        configs.each do |config|
+          config.build_settings["MARKETING_VERSION"] = next_version_number
+        end
+        project.save
+      end
+
+      private_class_method
+      def self.select_build_configuration_predicate(name, configuration)
+        is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.build_settings["PRODUCT_BUNDLE_IDENTIFIER"].nil?
+        is_build_valid_configuration &&= configuration.name == name unless name.nil?
+        return is_build_valid_configuration
+      end
+
+      def self.set_build_version_using_target(params, next_version_number)
+        project = Xcodeproj::Project.open(params[:xcodeproj])
+        if params[:target]
+          target = project.targets.detect { |t| t.name == params[:target] }
+        else
+          # firstly we are trying to find modern application target
+          target = project.targets.detect do |t|
+            t.kind_of?(Xcodeproj::Project::Object::PBXNativeTarget) &&
+              t.product_type == 'com.apple.product-type.application'
+          end
+          target = project.targets[0] if target.nil?
+        end
+
+        project.build_settings["MARKETING_VERSION"] = next_version_number
+        project.save
+      end
+
+      def self.set_build_version_using_scheme(params, next_version_number)
+        config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
+        project = FastlaneCore::Project.new(config)
+        project.select_scheme
+
+        project.build_settings["MARKETING_VERSION"] = next_version_number
+        project.save
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Increment build number in xcodeproj"
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.new(key: :bump_type,
+              env_name: "FL_VERSION_NUMBER_BUMP_TYPE",
+              description: "The type of this version bump. Available: patch, minor, major",
+              default_value: "patch",
+              verify_block: proc do |value|
+                UI.user_error!("Available values are 'patch', 'minor' and 'major'") unless ['patch', 'minor', 'major'].include? value
+              end),
+          FastlaneCore::ConfigItem.new(key: :version_number,
+                        env_name: "FL_VERSION_NUMBER_VERSION_NUMBER",
+                        description: "Change to a specific version. This will replace the bump type value",
+                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :omit_zero_patch_version,
+                        env_name: "FL_VERSION_NUMBER_OMIT_ZERO_PATCH_VERSION",
+                        description: "If true omits zero in patch version(so 42.10.0 will become 42.10 and 42.10.1 will remain 42.10.1)",
+                        default_value: false,
+                        optional: true,
+                        is_string: false),
+          FastlaneCore::ConfigItem.new(key: :bundle_id,
+                        env_name: "FL_APPSTORE_VERSION_NUMBER_BUNDLE_ID",
+                        description: "Bundle ID of the application",
+                        optional: true,
+                        conflicting_options: %i[xcodeproj target build_configuration_name scheme],
+                        is_string: true),
+          FastlaneCore::ConfigItem.new(key: :xcodeproj,
+                        env_name: "FL_VERSION_NUMBER_PROJECT",
+                        description: "optional, you must specify the path to your main Xcode project if it is not in the project root directory",
+                        optional: true,
+                        conflicting_options: [:bundle_id],
+                        verify_block: proc do |value|
+                          UI.user_error!("Please pass the path to the project, not the workspace") if value.end_with? ".xcworkspace"
+                          UI.user_error!("Could not find Xcode project at path '#{File.expand_path(value)}'") if !File.exist?(value) and !Helper.is_test?
+                        end),
+          FastlaneCore::ConfigItem.new(key: :target,
+                        env_name: "FL_VERSION_NUMBER_TARGET",
+                        optional: true,
+                        conflicting_options: %i[bundle_id scheme],
+                        description: "Specify a specific target if you have multiple per project, optional"),
+          FastlaneCore::ConfigItem.new(key: :scheme,
+                        env_name: "FL_VERSION_NUMBER_SCHEME",
+                        optional: true,
+                        conflicting_options: %i[bundle_id target],
+                        description: "Specify a specific scheme if you have multiple per project, optional"),
+          FastlaneCore::ConfigItem.new(key: :build_configuration_name,
+                        optional: true,
+                        conflicting_options: [:bundle_id],
+                        description: "Specify a specific build configuration if you have different Info.plist build settings for each configuration"),
+          FastlaneCore::ConfigItem.new(key: :version_source,
+                        optional: true,
+                        default_value: 'plist',
+                        verify_block: proc do |value|
+                          UI.user_error!("Available values are 'plist' and 'appstore'") unless ['plist', 'appstore'].include? value
+                        end,
+                        description: "Source version to increment. Available options: plist, appstore"),
+          FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
+                         description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
+                         is_string: false,
+                         default_value: false) # TODO: for backwards compatibility, should eventually turn to true?
+
+        ]
+      end
+
+      def self.authors
+        ["jdouglas-nz"]
+      end
+
+      def self.is_supported?(platform)
+        %i[ios mac android].include? platform
+      end
+    end
+  end
+    end

--- a/lib/fastlane/plugin/versioning/version.rb
+++ b/lib/fastlane/plugin/versioning/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Versioning
-    VERSION = "0.4.2"
+    VERSION = "0.4.3"
   end
 end

--- a/lib/fastlane/plugin/versioning/version.rb
+++ b/lib/fastlane/plugin/versioning/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Versioning
-    VERSION = "0.4.3"
+    VERSION = "0.4.0"
   end
 end

--- a/lib/fastlane/plugin/versioning/version.rb
+++ b/lib/fastlane/plugin/versioning/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Versioning
-    VERSION = "0.3.5"
+    VERSION = "0.4.1"
   end
 end

--- a/lib/fastlane/plugin/versioning/version.rb
+++ b/lib/fastlane/plugin/versioning/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Versioning
-    VERSION = "0.4.1"
+    VERSION = "0.4.2"
   end
 end

--- a/spec/fixtures/plist/New-Info.plist
+++ b/spec/fixtures/plist/New-Info.plist
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/spec/fixtures/xcodeproj/versioning_fixture_project.xcodeproj/project.pbxproj
+++ b/spec/fixtures/xcodeproj/versioning_fixture_project.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		D0A25DE72353C905000C5EB4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D0A25DEA2353C905000C5EB4 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		D0A25DED2353C905000C5EB4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		D0A25DEF2353C905000C5EB4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		D0A25DEF2353C905000C5EB4 /* New-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = New-Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -40,7 +40,7 @@
 		D0A25DD52353C902000C5EB4 = {
 			isa = PBXGroup;
 			children = (
-				D0A25DE02353C902000C5EB4 /* VersioningFixtureProject */,
+				D0A25DE02353C902000C5EB4 /* versioning_fixture_project */,
 				D0A25DDF2353C902000C5EB4 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -53,7 +53,7 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		D0A25DE02353C902000C5EB4 /* VersioningFixtureProject */ = {
+		D0A25DE02353C902000C5EB4 /* versioning_fixture_project */ = {
 			isa = PBXGroup;
 			children = (
 				D0A25DE12353C902000C5EB4 /* AppDelegate.swift */,
@@ -61,10 +61,10 @@
 				D0A25DE52353C902000C5EB4 /* ContentView.swift */,
 				D0A25DE72353C905000C5EB4 /* Assets.xcassets */,
 				D0A25DEC2353C905000C5EB4 /* LaunchScreen.storyboard */,
-				D0A25DEF2353C905000C5EB4 /* Info.plist */,
+				D0A25DEF2353C905000C5EB4 /* New-Info.plist */,
 				D0A25DE92353C905000C5EB4 /* Preview Content */,
 			);
-			path = VersioningFixtureProject;
+			path = versioning_fixture_project;
 			sourceTree = "<group>";
 		};
 		D0A25DE92353C905000C5EB4 /* Preview Content */ = {
@@ -91,7 +91,7 @@
 			dependencies = (
 			);
 			name = versioning_fixture_project;
-			productName = VersioningFixtureProject;
+			productName = versioning_fixture_project;
 			productReference = D0A25DDE2353C902000C5EB4 /* versioning_fixture_project.app */;
 			productType = "com.apple.product-type.application";
 		};
@@ -286,15 +286,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"VersioningFixtureProject/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "\"versioning_fixture_project/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
-				INFOPLIST_FILE = VersioningFixtureProject/Info.plist;
+				INFOPLIST_FILE = versioning_fixture_project/New-Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.community.action.versioning.VersioningFixtureProject;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.community.action.versioning.versioning_fixture_project;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -307,15 +307,15 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_ASSET_PATHS = "\"VersioningFixtureProject/Preview Content\"";
+				DEVELOPMENT_ASSET_PATHS = "\"versioning_fixture_project/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
-				INFOPLIST_FILE = VersioningFixtureProject/Info.plist;
+				INFOPLIST_FILE = versioning_fixture_project/New-Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 0.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.community.action.versioning.VersioningFixtureProject;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.community.action.versioning.versioning_fixture_project;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/spec/fixtures/xcodeproj/versioning_fixture_project.xcodeproj/project.pbxproj
+++ b/spec/fixtures/xcodeproj/versioning_fixture_project.xcodeproj/project.pbxproj
@@ -1,0 +1,349 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		D0A25DE22353C902000C5EB4 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A25DE12353C902000C5EB4 /* AppDelegate.swift */; };
+		D0A25DE42353C902000C5EB4 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A25DE32353C902000C5EB4 /* SceneDelegate.swift */; };
+		D0A25DE62353C902000C5EB4 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A25DE52353C902000C5EB4 /* ContentView.swift */; };
+		D0A25DE82353C905000C5EB4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D0A25DE72353C905000C5EB4 /* Assets.xcassets */; };
+		D0A25DEB2353C905000C5EB4 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D0A25DEA2353C905000C5EB4 /* Preview Assets.xcassets */; };
+		D0A25DEE2353C905000C5EB4 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D0A25DEC2353C905000C5EB4 /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		D0A25DDE2353C902000C5EB4 /* versioning_fixture_project.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = versioning_fixture_project.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D0A25DE12353C902000C5EB4 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		D0A25DE32353C902000C5EB4 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		D0A25DE52353C902000C5EB4 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		D0A25DE72353C905000C5EB4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D0A25DEA2353C905000C5EB4 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		D0A25DED2353C905000C5EB4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		D0A25DEF2353C905000C5EB4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		D0A25DDB2353C902000C5EB4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		D0A25DD52353C902000C5EB4 = {
+			isa = PBXGroup;
+			children = (
+				D0A25DE02353C902000C5EB4 /* VersioningFixtureProject */,
+				D0A25DDF2353C902000C5EB4 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		D0A25DDF2353C902000C5EB4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				D0A25DDE2353C902000C5EB4 /* versioning_fixture_project.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		D0A25DE02353C902000C5EB4 /* VersioningFixtureProject */ = {
+			isa = PBXGroup;
+			children = (
+				D0A25DE12353C902000C5EB4 /* AppDelegate.swift */,
+				D0A25DE32353C902000C5EB4 /* SceneDelegate.swift */,
+				D0A25DE52353C902000C5EB4 /* ContentView.swift */,
+				D0A25DE72353C905000C5EB4 /* Assets.xcassets */,
+				D0A25DEC2353C905000C5EB4 /* LaunchScreen.storyboard */,
+				D0A25DEF2353C905000C5EB4 /* Info.plist */,
+				D0A25DE92353C905000C5EB4 /* Preview Content */,
+			);
+			path = VersioningFixtureProject;
+			sourceTree = "<group>";
+		};
+		D0A25DE92353C905000C5EB4 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				D0A25DEA2353C905000C5EB4 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		D0A25DDD2353C902000C5EB4 /* versioning_fixture_project */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D0A25DF22353C905000C5EB4 /* Build configuration list for PBXNativeTarget "versioning_fixture_project" */;
+			buildPhases = (
+				D0A25DDA2353C902000C5EB4 /* Sources */,
+				D0A25DDB2353C902000C5EB4 /* Frameworks */,
+				D0A25DDC2353C902000C5EB4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = versioning_fixture_project;
+			productName = VersioningFixtureProject;
+			productReference = D0A25DDE2353C902000C5EB4 /* versioning_fixture_project.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		D0A25DD62353C902000C5EB4 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1110;
+				LastUpgradeCheck = 1110;
+				ORGANIZATIONNAME = "John Douglas";
+				TargetAttributes = {
+					D0A25DDD2353C902000C5EB4 = {
+						CreatedOnToolsVersion = 11.1;
+					};
+				};
+			};
+			buildConfigurationList = D0A25DD92353C902000C5EB4 /* Build configuration list for PBXProject "versioning_fixture_project" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = D0A25DD52353C902000C5EB4;
+			productRefGroup = D0A25DDF2353C902000C5EB4 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				D0A25DDD2353C902000C5EB4 /* versioning_fixture_project */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		D0A25DDC2353C902000C5EB4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D0A25DEE2353C905000C5EB4 /* LaunchScreen.storyboard in Resources */,
+				D0A25DEB2353C905000C5EB4 /* Preview Assets.xcassets in Resources */,
+				D0A25DE82353C905000C5EB4 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		D0A25DDA2353C902000C5EB4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				D0A25DE22353C902000C5EB4 /* AppDelegate.swift in Sources */,
+				D0A25DE42353C902000C5EB4 /* SceneDelegate.swift in Sources */,
+				D0A25DE62353C902000C5EB4 /* ContentView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		D0A25DEC2353C905000C5EB4 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				D0A25DED2353C905000C5EB4 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		D0A25DF02353C905000C5EB4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		D0A25DF12353C905000C5EB4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		D0A25DF32353C905000C5EB4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"VersioningFixtureProject/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = VersioningFixtureProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.community.action.versioning.VersioningFixtureProject;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		D0A25DF42353C905000C5EB4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"VersioningFixtureProject/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = VersioningFixtureProject/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.fastlane.community.action.versioning.VersioningFixtureProject;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		D0A25DD92353C902000C5EB4 /* Build configuration list for PBXProject "versioning_fixture_project" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D0A25DF02353C905000C5EB4 /* Debug */,
+				D0A25DF12353C905000C5EB4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D0A25DF22353C905000C5EB4 /* Build configuration list for PBXNativeTarget "versioning_fixture_project" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				D0A25DF32353C905000C5EB4 /* Debug */,
+				D0A25DF42353C905000C5EB4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = D0A25DD62353C902000C5EB4 /* Project object */;
+}

--- a/spec/fixtures/xcodeproj/versioning_fixture_project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/spec/fixtures/xcodeproj/versioning_fixture_project.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:versioning_fixture_project.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/spec/get_app_store_version_number_spec.rb
+++ b/spec/get_app_store_version_number_spec.rb
@@ -1,15 +1,10 @@
 require 'spec_helper'
-require 'webmock/rspec'
 
 describe Fastlane::Actions::GetAppStoreVersionNumberAction do
   describe "Get App Store Version Number Integration" do
     before do
-      copy_info_plist_fixture
-
-      fake_existing_response = File.read('./spec/fixtures/responses/numbers_lookup_response')
-      stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.apple.Numbers").to_return(fake_existing_response)
-      fake_nonexistent_response = File.read('./spec/fixtures/responses/nonexistent_lookup_response')
-      stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.some.nonexistent.app").to_return(fake_nonexistent_response)
+      copy_info_plist_fixtures
+      fake_api_responses
     end
 
     it "should return current AppStore version number for app with provided bundle id" do
@@ -36,7 +31,7 @@ describe Fastlane::Actions::GetAppStoreVersionNumberAction do
     end
 
     after do
-      remove_info_plist_fixture
+      cleanup_fixtures
     end
   end
 end

--- a/spec/get_build_number_from_plist_spec.rb
+++ b/spec/get_build_number_from_plist_spec.rb
@@ -2,17 +2,37 @@ require 'spec_helper'
 
 describe Fastlane::Actions::GetBuildNumberFromPlistAction do
   describe "Get Build Number from Info.plist Integration" do
+
+    let (:test_path) { "/tmp/fastlane/tests/fastlane" }
+    let (:plist_file) { File.join("plist/", "Info.plist") }
+
+    # Action parameters
+    let (:info_plist_file) { File.join(test_path, plist_file) }
+
     before do
-      copy_info_plist_fixture
+      copy_info_plist_fixtures
+      copy_xcodeproj_fixtures
     end
+
+    def current_build_number_plist 
+      Fastlane::FastFile.new.parse("lane :test do
+        get_info_plist_value(path: '#{info_plist_file}', key: 'CFBundleVersion')
+      end").runner.execute(:test)
+    end
+
+    def current_build_number_xcodeproj
+      Fastlane::FastFile.new.parse("lane :test do
+        get_build_number_from_xcodeproj
+      end").runner.execute(:test)
+    end 
 
     it "should return build number from Info.plist" do
       result = Fastlane::FastFile.new.parse("lane :test do
         get_build_number_from_plist
       end").runner.execute(:test)
-      expect(result).to eq("0.9.14.1")
+      expect(result).to eq(current_build_number_plist)
     end
-
+    
     it "should set BUILD_NUMBER shared value" do
       Fastlane::FastFile.new.parse("lane :test do
         get_build_number_from_plist
@@ -20,8 +40,15 @@ describe Fastlane::Actions::GetBuildNumberFromPlistAction do
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.9.14.1")
     end
 
+    it "should return build number from from xcodeproj if plist_build_setting_support: true" do
+      Fastlane::FastFile.new.parse("lane :test do
+        get_build_number_from_plist(plist_build_setting_support: true)
+      end").runner.execute(:test)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq(current_build_number_xcodeproj)
+    end
+
     after do
-      remove_info_plist_fixture
+      cleanup_fixtures
     end
   end
 end

--- a/spec/get_build_number_from_xcodeproj_spec.rb
+++ b/spec/get_build_number_from_xcodeproj_spec.rb
@@ -21,7 +21,7 @@ describe Fastlane::Actions::GetBuildNumberFromXcodeprojAction do
     end
 
     after do
-      remove_xcodeproj_fixtures
+      cleanup_fixtures
     end
   end
 end

--- a/spec/get_build_number_from_xcodeproj_spec.rb
+++ b/spec/get_build_number_from_xcodeproj_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::GetBuildNumberFromXcodeprojAction do
+  describe "Get Build Number from Xcodeproj Integration" do
+    before do
+      copy_xcodeproj_fixtures
+    end
+
+    it "should return build number from Xcodeproj" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        get_build_number_from_xcodeproj
+      end").runner.execute(:test)
+      expect(result).to eq("1")
+    end
+
+    it "should set BUILD_NUMBER shared value" do
+      Fastlane::FastFile.new.parse("lane :test do
+        get_build_number_from_xcodeproj
+      end").runner.execute(:test)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1")
+    end
+
+    after do
+      remove_xcodeproj_fixtures
+    end
+  end
+end

--- a/spec/get_info_plist_path_spec.rb
+++ b/spec/get_info_plist_path_spec.rb
@@ -3,23 +3,20 @@ require 'spec_helper'
 describe Fastlane::Actions::GetInfoPlistPathAction do
   describe "Get Info.plist Path Integration" do
     before do
-      # Create test folder
-      FileUtils.mkdir_p(test_path)
-      source = File.join(fixtures_path, proj_file)
-      destination = File.join(test_path, proj_file)
-
-      # Copy .xcodeproj fixture, as it will be modified during the test
-      FileUtils.cp_r(source, destination)
+      copy_xcodeproj_fixtures
+      copy_info_plist_fixtures
     end
 
     describe "for targets with the same Info.plist paths for all build configurations" do
       # Variables
       let (:test_path) { "/tmp/fastlane/tests/fastlane" }
-      let (:fixtures_path) { "./spec/fixtures/xcodeproj" }
+      let (:fixtures_path) { "./spec/fixtures" }
+
+      let (:xcodeproj_test_path) { File.join(test_path, "xcodeproj/") }
       let (:proj_file) { "bundle.xcodeproj" }
 
       # Action parameters
-      let (:xcodeproj) { File.join(test_path, proj_file) }
+      let (:xcodeproj) { File.join(xcodeproj_test_path, proj_file) }
       let (:target) { "bundle" }
 
       it "should return Info.plist path with explicitly provided xcodeproj and target" do
@@ -29,7 +26,7 @@ describe Fastlane::Actions::GetInfoPlistPathAction do
             target: '#{target}'
           })
         end").runner.execute(:test)
-        expect(result).to eq(File.join(test_path, "bundle/Info.plist"))
+        expect(result).to eq(File.join(xcodeproj_test_path, "bundle/Info.plist"))
       end
 
       it "should detect xcodeproj in the root directory and return Info.plist path for explicitly provided target" do
@@ -38,7 +35,7 @@ describe Fastlane::Actions::GetInfoPlistPathAction do
             target: '#{target}'
           })
         end").runner.execute(:test)
-        expect(result).to eq(File.join(test_path, "bundle/Info.plist"))
+        expect(result).to eq(File.join(xcodeproj_test_path, "bundle/Info.plist"))
       end
 
       it "should detect target and return its Info.plist path for explicitly provided xcodeproj" do
@@ -47,24 +44,26 @@ describe Fastlane::Actions::GetInfoPlistPathAction do
             xcodeproj: '#{xcodeproj}'
           })
         end").runner.execute(:test)
-        expect(result).to eq(File.join(test_path, "bundle/Info.plist"))
+        expect(result).to eq(File.join(xcodeproj_test_path, "bundle/Info.plist"))
       end
 
       it "should detect xcodeproj in the root directory and target and return its Info.plist path" do
         result = Fastlane::FastFile.new.parse("lane :test do
           get_info_plist_path
         end").runner.execute(:test)
-        expect(result).to eq(File.join(test_path, "bundle/Info.plist"))
+        expect(result).to eq(File.join(xcodeproj_test_path, "bundle/Info.plist"))
       end
     end
 
     describe "for targets with different Info.plist paths for all build configurations" do
       let (:test_path) { "/tmp/fastlane/tests/fastlane" }
       let (:fixtures_path) { "./spec/fixtures/xcodeproj" }
+
+      let (:xcodeproj_test_path) { File.join(test_path, "xcodeproj/") }
       let (:proj_file) { "get_info_plist_path.xcodeproj" }
 
       # Action parameters
-      let (:xcodeproj) { File.join(test_path, proj_file) }
+      let (:xcodeproj) { File.join(xcodeproj_test_path, proj_file) }
       let (:target) { "get_info_plist_path" }
 
       it "should return its Info.plist path" do
@@ -75,7 +74,7 @@ describe Fastlane::Actions::GetInfoPlistPathAction do
             build_configuration_name: 'Debug'
           })
         end").runner.execute(:test)
-        expect(result).to eq(File.join(test_path, "get_info_plist_path/Info_Debug.plist"))
+        expect(result).to eq(File.join(xcodeproj_test_path, "get_info_plist_path/Info_Debug.plist"))
 
         # it will also check an $(SRCROOT) substitution
         result = Fastlane::FastFile.new.parse("lane :test do
@@ -85,16 +84,18 @@ describe Fastlane::Actions::GetInfoPlistPathAction do
             build_configuration_name: 'Release'
           })
         end").runner.execute(:test)
-        expect(result).to eq(File.join(test_path, "get_info_plist_path/Info_Release.plist"))
+        expect(result).to eq(File.join(xcodeproj_test_path, "get_info_plist_path/Info_Release.plist"))
       end
     end
 
     describe "for Info.plist path containing ${SRCROOT}" do
       let (:test_path) { "/tmp/fastlane/tests/fastlane" }
       let (:fixtures_path) { "./spec/fixtures/xcodeproj" }
+      let (:xcodeproj_test_path) { File.join(test_path, "xcodeproj/") }
+
       let (:proj_file) { "get_info_plist_path2.xcodeproj" }
 
-      let (:xcodeproj) { File.join(test_path, proj_file) }
+      let (:xcodeproj) { File.join(xcodeproj_test_path, proj_file) }
       let (:target) { "get_info_plist_path" }
 
       it "should substitute ${SRCROOT} variable with project root path" do
@@ -105,13 +106,12 @@ describe Fastlane::Actions::GetInfoPlistPathAction do
           build_configuration_name: 'Release'
         })
         end").runner.execute(:test)
-        expect(result).to eq(File.join(test_path, "get_info_plist_path/Info_Release.plist"))
+        expect(result).to eq(File.join(xcodeproj_test_path, "get_info_plist_path/Info_Release.plist"))
       end
     end
 
     after do
-      # Clean up files
-      FileUtils.rm_r(test_path)
+      cleanup_fixtures
     end
   end
 end

--- a/spec/get_info_plist_path_spec.rb
+++ b/spec/get_info_plist_path_spec.rb
@@ -109,8 +109,6 @@ describe Fastlane::Actions::GetInfoPlistPathAction do
       end
     end
 
-
-
     after do
       # Clean up files
       FileUtils.rm_r(test_path)

--- a/spec/get_version_number_from_plist_spec.rb
+++ b/spec/get_version_number_from_plist_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Fastlane::Actions::GetVersionNumberFromPlistAction do
   describe "Get Version Number from Info.plist Integration" do
     before do
-      copy_info_plist_fixture
+      copy_info_plist_fixtures
     end
 
     it "should return version number from Info.plist" do
@@ -21,7 +21,7 @@ describe Fastlane::Actions::GetVersionNumberFromPlistAction do
     end
 
     after do
-      remove_info_plist_fixture
+      cleanup_fixtures
     end
   end
 end

--- a/spec/get_version_number_from_xcodeproj_spec.rb
+++ b/spec/get_version_number_from_xcodeproj_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::GetVersionNumberFromXcodeprojAction do
+  describe "Get Version Number from Xcodeproject" do
+    before do
+      copy_xcodeproj_fixtures
+    end
+
+    it "should return version number from Xcodeproject" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        get_version_number_from_xcodeproj
+      end").runner.execute(:test)
+      expect(result).to eq("0.0.1")
+    end
+
+    it "should set VERSION_NUMBER shared value" do
+      Fastlane::FastFile.new.parse("lane :test do
+        get_version_number_from_xcodeproj
+      end").runner.execute(:test)
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("0.0.1")
+    end
+
+    after do
+      remove_xcodeproj_fixtures
+    end
+  end
+end

--- a/spec/get_version_number_from_xcodeproj_spec.rb
+++ b/spec/get_version_number_from_xcodeproj_spec.rb
@@ -21,7 +21,7 @@ describe Fastlane::Actions::GetVersionNumberFromXcodeprojAction do
     end
 
     after do
-      remove_xcodeproj_fixtures
+      cleanup_fixtures
     end
   end
 end

--- a/spec/increment_build_number_in_plist_additions_spec.rb
+++ b/spec/increment_build_number_in_plist_additions_spec.rb
@@ -2,36 +2,37 @@ require 'spec_helper'
 
 describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
   describe "Increment new format of Build Numberin Info.plist Integration" do
+
     let (:test_path) { "/tmp/fastlane/tests/fastlane" }
-    let (:fixtures_path) { "./spec/fixtures/plist" }
-    let (:plist_file) { "Info.plist" }
+    let (:plist_file) { File.join("plist/", "Info.plist") }
 
     # Action parameters
     let (:info_plist_file) { File.join(test_path, plist_file) }
 
     before do
-      FileUtils.mkdir_p(test_path)
-      source = File.join(fixtures_path, 'New-Info.plist')
-      destination = File.join(test_path, plist_file)
-
-      FileUtils.cp_r(source, destination)
-
       copy_xcodeproj_fixtures
+      copy_info_plist_fixtures
     end
 
-    def current_version
+    def current_xcodeproj_build_number
       Fastlane::FastFile.new.parse("lane :test do
         get_build_number_from_xcodeproj
       end").runner.execute(:test)
     end
 
-    it "should set explicitly provided build number to xcodeproj if the value is non literal" do
+    def current_build_number_plist 
+      Fastlane::FastFile.new.parse("lane :test do
+        get_info_plist_value(path: '#{info_plist_file}', key: 'CFBundleVersion')
+      end").runner.execute(:test)
+    end
+
+    it "should set explicitly provided build number to plist if the value is non literal" do
       result = Fastlane::FastFile.new.parse("lane :test do
         increment_build_number_in_plist(build_number: '0.0.3')
       end").runner.execute(:test)
 
-      expect(current_version).to eq("1")
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1")
+      expect(current_build_number_plist).to eq("0.0.3")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.3")
     end
 
     it "should set explicitly provided build number to xcodeproj if the value is non literal with plist_build_setting_support: true" do
@@ -39,7 +40,7 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
         increment_build_number_in_plist(plist_build_setting_support: true, build_number: '0.0.4')
       end").runner.execute(:test)
 
-      expect(current_version).to eq("0.0.4")
+      expect(current_xcodeproj_build_number).to eq("0.0.4")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.4")
     end
 
@@ -48,12 +49,12 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
         increment_build_number_in_plist(plist_build_setting_support: true, build_number: '0.0.4')
       end").runner.execute(:test)
 
-      expect(current_version).to eq("0.0.4")
+      expect(current_xcodeproj_build_number).to eq("0.0.4")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.4")
     end
 
     after do
-      FileUtils.rm_r(test_path)
+      cleanup_fixtures
     end
   end
 end

--- a/spec/increment_build_number_in_plist_additions_spec.rb
+++ b/spec/increment_build_number_in_plist_additions_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
+  
+    describe "Increment new format of Build Numberin Info.plist Integration" do
+    
+    let (:test_path) { "/tmp/fastlane/tests/fastlane" }
+    let (:fixtures_path) { "./spec/fixtures/plist" }
+    let (:plist_file) { "Info.plist" }
+
+    # Action parameters
+    let (:info_plist_file) { File.join(test_path, plist_file) }
+
+    before do
+      FileUtils.mkdir_p(test_path)
+      source = File.join(fixtures_path, 'New-Info.plist')
+      destination = File.join(test_path, plist_file)
+
+      FileUtils.cp_r(source, destination)
+      
+      copy_xcodeproj_fixtures
+    end
+
+    def current_version
+      Fastlane::FastFile.new.parse("lane :test do
+        get_info_plist_value(path: '#{info_plist_file}', key: 'CFBundleVersion')
+      end").runner.execute(:test)
+    end
+
+    it "should set explicitly provided version number to xcodeproj if the value is non literal" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_build_number_in_plist(build_number: '0.0.3')
+      end").runner.execute(:test)
+
+      
+      expect(current_version).to eq("0.0.3")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.3")
+    end
+
+    it "should set explicitly provided version number to xcodeproj if the value is non literal with plist_build_setting_support: true" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_build_number_in_plist(plist_build_setting_support: true)
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("0.9.14.2")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.9.14.2")
+    end
+
+    after do
+      FileUtils.rm_r(test_path)
+    end
+  end
+end

--- a/spec/increment_build_number_in_plist_additions_spec.rb
+++ b/spec/increment_build_number_in_plist_additions_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
-  describe "Increment new format of Build Numberin Info.plist Integration" do
+  describe "Increment new format of Build Number in Info.plist Integration" do
 
     let (:test_path) { "/tmp/fastlane/tests/fastlane" }
     let (:plist_file) { File.join("plist/", "Info.plist") }
@@ -11,7 +11,7 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
 
     before do
       copy_xcodeproj_fixtures
-      copy_info_plist_fixtures
+      copy_non_literal_style_plist
     end
 
     def current_xcodeproj_build_number
@@ -26,15 +26,6 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
       end").runner.execute(:test)
     end
 
-    it "should set explicitly provided build number to plist if the value is non literal" do
-      result = Fastlane::FastFile.new.parse("lane :test do
-        increment_build_number_in_plist(build_number: '0.0.3')
-      end").runner.execute(:test)
-
-      expect(current_build_number_plist).to eq("0.0.3")
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.3")
-    end
-
     it "should set explicitly provided build number to xcodeproj if the value is non literal with plist_build_setting_support: true" do
       result = Fastlane::FastFile.new.parse("lane :test do
         increment_build_number_in_plist(plist_build_setting_support: true, build_number: '0.0.4')
@@ -46,11 +37,29 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
 
     it "should increment number to xcodeproj if the value is non literal with plist_build_setting_support: true" do
       result = Fastlane::FastFile.new.parse("lane :test do
-        increment_build_number_in_plist(plist_build_setting_support: true, build_number: '0.0.4')
+        increment_build_number_in_plist(plist_build_setting_support: true)
       end").runner.execute(:test)
 
-      expect(current_xcodeproj_build_number).to eq("0.0.4")
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.4")
+      expect(current_xcodeproj_build_number).to eq("2")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("2")
+    end
+
+    it "should not set explicitly provided build number to xcodeproj if the plist_build_setting_support: false" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_build_number_in_plist(build_number: '0.0.3')
+      end").runner.execute(:test)
+
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.3")
+      expect(current_xcodeproj_build_number).to_not eq("0.0.3")
+    end
+
+    it "should not increment number to plist with plist_build_setting_support: true" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_plist(plist_build_setting_support: true, version_number: '0.0.4')
+      end").runner.execute(:test)
+
+      expect(current_build_number_plist).to_not eq("0.0.4")
+      expect(current_build_number_plist).to eq("$(CURRENT_PROJECT_VERSION)")
     end
 
     after do

--- a/spec/increment_build_number_in_plist_additions_spec.rb
+++ b/spec/increment_build_number_in_plist_additions_spec.rb
@@ -23,27 +23,35 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
 
     def current_version
       Fastlane::FastFile.new.parse("lane :test do
-        get_info_plist_value(path: '#{info_plist_file}', key: 'CFBundleVersion')
+        get_build_number_from_xcodeproj
       end").runner.execute(:test)
     end
 
-    it "should set explicitly provided version number to xcodeproj if the value is non literal" do
+    it "should set explicitly provided build number to xcodeproj if the value is non literal" do
       result = Fastlane::FastFile.new.parse("lane :test do
         increment_build_number_in_plist(build_number: '0.0.3')
       end").runner.execute(:test)
 
-      
-      expect(current_version).to eq("0.0.3")
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.3")
+      expect(current_version).to eq("1")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1")
     end
 
-    it "should set explicitly provided version number to xcodeproj if the value is non literal with plist_build_setting_support: true" do
+    it "should set explicitly provided build number to xcodeproj if the value is non literal with plist_build_setting_support: true" do
       result = Fastlane::FastFile.new.parse("lane :test do
-        increment_build_number_in_plist(plist_build_setting_support: true)
+        increment_build_number_in_plist(plist_build_setting_support: true, build_number: '0.0.4')
       end").runner.execute(:test)
 
-      expect(current_version).to eq("0.9.14.2")
-      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.9.14.2")
+      expect(current_version).to eq("0.0.4")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.4")
+    end
+
+    it "should increment number to xcodeproj if the value is non literal with plist_build_setting_support: true" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_build_number_in_plist(plist_build_setting_support: true, build_number: '0.0.4')
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("0.0.4")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.0.4")
     end
 
     after do

--- a/spec/increment_build_number_in_plist_additions_spec.rb
+++ b/spec/increment_build_number_in_plist_additions_spec.rb
@@ -1,9 +1,7 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
-  
-    describe "Increment new format of Build Numberin Info.plist Integration" do
-    
+  describe "Increment new format of Build Numberin Info.plist Integration" do
     let (:test_path) { "/tmp/fastlane/tests/fastlane" }
     let (:fixtures_path) { "./spec/fixtures/plist" }
     let (:plist_file) { "Info.plist" }
@@ -17,7 +15,7 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
       destination = File.join(test_path, plist_file)
 
       FileUtils.cp_r(source, destination)
-      
+
       copy_xcodeproj_fixtures
     end
 

--- a/spec/increment_build_number_in_plist_spec.rb
+++ b/spec/increment_build_number_in_plist_spec.rb
@@ -3,21 +3,17 @@ require 'spec_helper'
 describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
   describe "Increment Build Number in Info.plist Integration" do
     let (:test_path) { "/tmp/fastlane/tests/fastlane" }
-    let (:fixtures_path) { "./spec/fixtures/plist" }
-    let (:plist_file) { "Info.plist" }
+    let (:plist_file) { File.join("plist/", "Info.plist") }
 
     # Action parameters
     let (:info_plist_file) { File.join(test_path, plist_file) }
 
     before do
-      FileUtils.mkdir_p(test_path)
-      source = File.join(fixtures_path, plist_file)
-      destination = File.join(test_path, plist_file)
-
-      FileUtils.cp_r(source, destination)
+      copy_info_plist_fixtures
+      copy_xcodeproj_fixtures
     end
 
-    def current_version
+    def current_build_number
       Fastlane::FastFile.new.parse("lane :test do
         get_info_plist_value(path: '#{info_plist_file}', key: 'CFBundleVersion')
       end").runner.execute(:test)
@@ -28,7 +24,7 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
         increment_build_number_in_plist(build_number: '1.9.4.1')
       end").runner.execute(:test)
 
-      expect(current_version).to eq("1.9.4.1")
+      expect(current_build_number).to eq("1.9.4.1")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1.9.4.1")
     end
 
@@ -37,12 +33,12 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
         increment_build_number_in_plist
       end").runner.execute(:test)
 
-      expect(current_version).to eq("0.9.14.2")
+      expect(current_build_number).to eq("0.9.14.2")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.9.14.2")
     end
 
     after do
-      FileUtils.rm_r(test_path)
+      cleanup_fixtures
     end
   end
 end

--- a/spec/increment_build_number_in_plist_spec.rb
+++ b/spec/increment_build_number_in_plist_spec.rb
@@ -13,18 +13,18 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
       copy_xcodeproj_fixtures
     end
 
-    def current_build_number
+    def current_build_number_plist
       Fastlane::FastFile.new.parse("lane :test do
         get_info_plist_value(path: '#{info_plist_file}', key: 'CFBundleVersion')
       end").runner.execute(:test)
     end
 
-    it "should set explicitly provided version number to Info.plist" do
+    it "should set explicitly provided build number to Info.plist" do
       result = Fastlane::FastFile.new.parse("lane :test do
         increment_build_number_in_plist(build_number: '1.9.4.1')
       end").runner.execute(:test)
 
-      expect(current_build_number).to eq("1.9.4.1")
+      expect(current_build_number_plist).to eq("1.9.4.1")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1.9.4.1")
     end
 
@@ -33,7 +33,7 @@ describe Fastlane::Actions::IncrementBuildNumberInPlistAction do
         increment_build_number_in_plist
       end").runner.execute(:test)
 
-      expect(current_build_number).to eq("0.9.14.2")
+      expect(current_build_number_plist).to eq("0.9.14.2")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("0.9.14.2")
     end
 

--- a/spec/increment_build_number_in_xcodeproj_spec.rb
+++ b/spec/increment_build_number_in_xcodeproj_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::IncrementBuildNumberInXcodeprojAction do
+  describe "Increment Version Number in xcodeproj Integration" do
+    let (:test_path) { "/tmp/fastlane/tests/fastlane" }
+    let (:fixtures_path) { "./spec/fixtures/plist" }
+    let (:plist_file) { "Info.plist" }
+
+    # Action parameters
+    let (:info_plist_file) { File.join(test_path, plist_file) }
+
+    before do
+      FileUtils.mkdir_p(test_path)
+      source = File.join(fixtures_path, 'New-Info.plist')
+      destination = File.join(test_path, plist_file)
+
+      FileUtils.cp_r(source, destination)
+      
+      copy_xcodeproj_fixtures
+    end
+
+    def current_version
+      Fastlane::FastFile.new.parse("lane :test do
+        get_build_number_from_xcodeproj
+      end").runner.execute(:test)
+    end
+
+    it "should set explicitly provided version number to xcodeproj" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_build_number_in_xcodeproj(build_number: '1.9.4.1')
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("1.9.4.1")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1.9.4.1")
+    end
+
+    it "should increment build number by default and set it to xcodeproj" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_build_number_in_xcodeproj
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("2")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("2")
+    end
+
+    after do
+      FileUtils.rm_r(test_path)
+    end
+
+  end
+end

--- a/spec/increment_build_number_in_xcodeproj_spec.rb
+++ b/spec/increment_build_number_in_xcodeproj_spec.rb
@@ -2,24 +2,12 @@ require 'spec_helper'
 
 describe Fastlane::Actions::IncrementBuildNumberInXcodeprojAction do
   describe "Increment Version Number in xcodeproj Integration" do
-    let (:test_path) { "/tmp/fastlane/tests/fastlane" }
-    let (:fixtures_path) { "./spec/fixtures/plist" }
-    let (:plist_file) { "Info.plist" }
-
-    # Action parameters
-    let (:info_plist_file) { File.join(test_path, plist_file) }
 
     before do
-      FileUtils.mkdir_p(test_path)
-      source = File.join(fixtures_path, 'New-Info.plist')
-      destination = File.join(test_path, plist_file)
-
-      FileUtils.cp_r(source, destination)
-
       copy_xcodeproj_fixtures
     end
 
-    def current_version
+    def current_build_number
       Fastlane::FastFile.new.parse("lane :test do
         get_build_number_from_xcodeproj
       end").runner.execute(:test)
@@ -30,7 +18,7 @@ describe Fastlane::Actions::IncrementBuildNumberInXcodeprojAction do
         increment_build_number_in_xcodeproj(build_number: '1.9.4.1')
       end").runner.execute(:test)
 
-      expect(current_version).to eq("1.9.4.1")
+      expect(current_build_number).to eq("1.9.4.1")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("1.9.4.1")
     end
 
@@ -39,12 +27,12 @@ describe Fastlane::Actions::IncrementBuildNumberInXcodeprojAction do
         increment_build_number_in_xcodeproj
       end").runner.execute(:test)
 
-      expect(current_version).to eq("2")
+      expect(current_build_number).to eq("2")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("2")
     end
 
     after do
-      FileUtils.rm_r(test_path)
+      cleanup_fixtures
     end
   end
 end

--- a/spec/increment_build_number_in_xcodeproj_spec.rb
+++ b/spec/increment_build_number_in_xcodeproj_spec.rb
@@ -15,7 +15,7 @@ describe Fastlane::Actions::IncrementBuildNumberInXcodeprojAction do
       destination = File.join(test_path, plist_file)
 
       FileUtils.cp_r(source, destination)
-      
+
       copy_xcodeproj_fixtures
     end
 
@@ -46,6 +46,5 @@ describe Fastlane::Actions::IncrementBuildNumberInXcodeprojAction do
     after do
       FileUtils.rm_r(test_path)
     end
-
   end
 end

--- a/spec/increment_version_in_plist_additions_spec.rb
+++ b/spec/increment_version_in_plist_additions_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::IncrementVersionNumberInPlistAction do
+  describe "Increment new format of Version Number in Info.plist Integration" do
+
+    let (:test_path) { "/tmp/fastlane/tests/fastlane" }
+    let (:plist_file) { File.join("plist/", "Info.plist") }
+
+    # Action parameters
+    let (:info_plist_file) { File.join(test_path, plist_file) }
+
+    before do
+      copy_xcodeproj_fixtures
+      copy_non_literal_style_plist
+    end
+
+    def current_xcodeproj_version_number
+      Fastlane::FastFile.new.parse("lane :test do
+        get_version_number_from_xcodeproj
+      end").runner.execute(:test)
+    end
+
+    def current_version_number_plist 
+      Fastlane::FastFile.new.parse("lane :test do
+        get_info_plist_value(path: '#{info_plist_file}', key: 'CFBundleShortVersionString')
+      end").runner.execute(:test)
+    end
+
+    it "should not set explicitly provided version number to xcodeproj if the plist_build_setting_support: false" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_plist(version_number: '0.0.3')
+      end").runner.execute(:test)
+
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("0.0.3")
+      expect(current_xcodeproj_version_number).to_not eq("0.0.3")
+    end
+
+    it "should set explicitly provided build number to xcodeproj if the value is non literal with plist_build_setting_support: true" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_plist(plist_build_setting_support: true, version_number: '0.0.4')
+      end").runner.execute(:test)
+
+      expect(current_xcodeproj_version_number).to eq("0.0.4")
+      expect(current_version_number_plist).to_not eq("0.0.4")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("0.0.4")
+    end
+
+    it "should not increment number to plist with plist_build_setting_support: true" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_plist(plist_build_setting_support: true, version_number: '0.0.4')
+      end").runner.execute(:test)
+
+      expect(current_version_number_plist).to_not eq("0.0.4")
+      expect(current_version_number_plist).to eq("$(MARKETING_VERSION)")
+    end
+
+    after do
+      cleanup_fixtures
+    end
+  end
+end

--- a/spec/increment_version_number_in_plist_spec.rb
+++ b/spec/increment_version_number_in_plist_spec.rb
@@ -3,26 +3,15 @@ require 'spec_helper'
 describe Fastlane::Actions::IncrementVersionNumberInPlistAction do
   describe "Increment Version Number in Info.plist Integration" do
     let (:test_path) { "/tmp/fastlane/tests/fastlane" }
-    let (:fixtures_path) { "./spec/fixtures/plist" }
-    let (:plist_file) { "Info.plist" }
+    let (:plist_file) { File.join("plist/", "Info.plist") }
 
     # Action parameters
     let (:info_plist_file) { File.join(test_path, plist_file) }
 
     before do
-      FileUtils.mkdir_p(test_path)
-      source = File.join(fixtures_path, plist_file)
-      destination = File.join(test_path, plist_file)
-
-      FileUtils.cp_r(source, destination)
-
       copy_xcodeproj_fixtures
-      copy_info_plist_fixture
-
-      fake_existing_response = File.read('./spec/fixtures/responses/numbers_lookup_response')
-      stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.apple.Numbers").to_return(fake_existing_response)
-      fake_nonexistent_response = File.read('./spec/fixtures/responses/nonexistent_lookup_response')
-      stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.some.nonexistent.app").to_return(fake_nonexistent_response)
+      copy_info_plist_fixtures
+      fake_api_responses
     end
 
     def current_version
@@ -95,7 +84,7 @@ describe Fastlane::Actions::IncrementVersionNumberInPlistAction do
     end
 
     after do
-      FileUtils.rm_r(test_path)
+      cleanup_fixtures
     end
   end
 end

--- a/spec/increment_version_number_in_plist_spec.rb
+++ b/spec/increment_version_number_in_plist_spec.rb
@@ -15,6 +15,9 @@ describe Fastlane::Actions::IncrementVersionNumberInPlistAction do
       destination = File.join(test_path, plist_file)
 
       FileUtils.cp_r(source, destination)
+      
+      copy_xcodeproj_fixtures
+      copy_info_plist_fixture
 
       fake_existing_response = File.read('./spec/fixtures/responses/numbers_lookup_response')
       stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.apple.Numbers").to_return(fake_existing_response)

--- a/spec/increment_version_number_in_plist_spec.rb
+++ b/spec/increment_version_number_in_plist_spec.rb
@@ -15,7 +15,7 @@ describe Fastlane::Actions::IncrementVersionNumberInPlistAction do
       destination = File.join(test_path, plist_file)
 
       FileUtils.cp_r(source, destination)
-      
+
       copy_xcodeproj_fixtures
       copy_info_plist_fixture
 

--- a/spec/increment_version_number_in_xcodeproj_spec.rb
+++ b/spec/increment_version_number_in_xcodeproj_spec.rb
@@ -17,13 +17,13 @@ describe Fastlane::Actions::IncrementVersionNumberInXcodeprojAction do
 
       FileUtils.cp_r(source, destination)
 
+      copy_xcodeproj_fixtures
+      copy_info_plist_fixture
+
       fake_existing_response = File.read('./spec/fixtures/responses/numbers_lookup_response')
       stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.apple.Numbers").to_return(fake_existing_response)
       fake_nonexistent_response = File.read('./spec/fixtures/responses/nonexistent_lookup_response')
       stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.some.nonexistent.app").to_return(fake_nonexistent_response)
-
-      copy_xcodeproj_fixtures
-      copy_info_plist_fixture
     end
 
     def current_version
@@ -78,7 +78,7 @@ describe Fastlane::Actions::IncrementVersionNumberInXcodeprojAction do
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("0.1")
     end
 
-    it "should bump major version and set it to Info.plist" do
+    it "should bump major version and set it to xcodeproj" do
       result = Fastlane::FastFile.new.parse("lane :test do
         increment_version_number_in_xcodeproj(bump_type: 'major')
       end").runner.execute(:test)

--- a/spec/increment_version_number_in_xcodeproj_spec.rb
+++ b/spec/increment_version_number_in_xcodeproj_spec.rb
@@ -2,27 +2,11 @@ require 'spec_helper'
 
 describe Fastlane::Actions::IncrementVersionNumberInXcodeprojAction do
   describe "Increment Version Number in xcodeproj Integration" do
-    let (:test_path) { "/tmp/fastlane/tests/fastlane" }
-    let (:fixtures_path) { "./spec/fixtures/plist" }
-    let (:plist_file) { "Info.plist" }
-
-    # Action parameters
-    let (:info_plist_file) { File.join(test_path, plist_file) }
 
     before do
-      FileUtils.mkdir_p(test_path)
-      source = File.join(fixtures_path, 'New-Info.plist')
-      destination = File.join(test_path, plist_file)
-
-      FileUtils.cp_r(source, destination)
-
       copy_xcodeproj_fixtures
-      copy_info_plist_fixture
-
-      fake_existing_response = File.read('./spec/fixtures/responses/numbers_lookup_response')
-      stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.apple.Numbers").to_return(fake_existing_response)
-      fake_nonexistent_response = File.read('./spec/fixtures/responses/nonexistent_lookup_response')
-      stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.some.nonexistent.app").to_return(fake_nonexistent_response)
+      copy_info_plist_fixtures
+      fake_api_responses
     end
 
     def current_version
@@ -96,7 +80,7 @@ describe Fastlane::Actions::IncrementVersionNumberInXcodeprojAction do
     end
 
     after do
-      FileUtils.rm_r(test_path)
+      cleanup_fixtures
     end
   end
 end

--- a/spec/increment_version_number_in_xcodeproj_spec.rb
+++ b/spec/increment_version_number_in_xcodeproj_spec.rb
@@ -1,0 +1,104 @@
+require 'spec_helper'
+
+describe Fastlane::Actions::IncrementVersionNumberInXcodeprojAction do
+  
+  describe "Increment Version Number in xcodeproj Integration" do
+    let (:test_path) { "/tmp/fastlane/tests/fastlane" }
+    let (:fixtures_path) { "./spec/fixtures/plist" }
+    let (:plist_file) { "Info.plist" }
+
+    # Action parameters
+    let (:info_plist_file) { File.join(test_path, plist_file) }
+
+    before do
+      FileUtils.mkdir_p(test_path)
+      source = File.join(fixtures_path, 'New-Info.plist')
+      destination = File.join(test_path, plist_file)
+
+      FileUtils.cp_r(source, destination)
+
+      fake_existing_response = File.read('./spec/fixtures/responses/numbers_lookup_response')
+      stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.apple.Numbers").to_return(fake_existing_response)
+      fake_nonexistent_response = File.read('./spec/fixtures/responses/nonexistent_lookup_response')
+      stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.some.nonexistent.app").to_return(fake_nonexistent_response)
+
+      copy_xcodeproj_fixtures
+      copy_info_plist_fixture
+    end
+
+    def current_version
+      version = Fastlane::FastFile.new.parse("lane :test do
+        get_version_number_from_xcodeproj
+      end").runner.execute(:test)
+      version
+    end
+
+    it "should set explicitly provided version number to xcodeproj" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_xcodeproj(version_number: '1.9.4')
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("1.9.4")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("1.9.4")
+    end
+
+    it "should bump patch version by default and set it to xcodeproj" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_xcodeproj
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("0.0.2")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("0.0.2")
+    end
+
+    it "should bump patch version and set it to xcodeproj" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_xcodeproj(bump_type: 'patch')
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("0.0.2")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("0.0.2")
+    end
+
+    it "should bump minor version and set it to xcodeproj" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_xcodeproj(bump_type: 'minor')
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("0.1.0")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("0.1.0")
+    end
+
+    it "should omit zero in patch version if omit_zero_patch_version is true" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_xcodeproj(bump_type: 'minor', omit_zero_patch_version: true)
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("0.1")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("0.1")
+    end
+
+    it "should bump major version and set it to Info.plist" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_xcodeproj(bump_type: 'major')
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("1.0.0")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("1.0.0")
+    end
+
+    it "should bump version using App Store version as a source" do
+      result = Fastlane::FastFile.new.parse("lane :test do
+        increment_version_number_in_xcodeproj(bump_type: 'major', version_source: 'appstore')
+      end").runner.execute(:test)
+
+      expect(current_version).to eq("3.0.0")
+      expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("3.0.0")
+    end
+
+    after do
+      FileUtils.rm_r(test_path)
+    end
+
+  end
+end

--- a/spec/increment_version_number_in_xcodeproj_spec.rb
+++ b/spec/increment_version_number_in_xcodeproj_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Fastlane::Actions::IncrementVersionNumberInXcodeprojAction do
-  
   describe "Increment Version Number in xcodeproj Integration" do
     let (:test_path) { "/tmp/fastlane/tests/fastlane" }
     let (:fixtures_path) { "./spec/fixtures/plist" }
@@ -99,6 +98,5 @@ describe Fastlane::Actions::IncrementVersionNumberInXcodeprojAction do
     after do
       FileUtils.rm_r(test_path)
     end
-
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 # This module is only used to check the environment is currently a testing env
 module SpecHelper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,13 +24,23 @@ end
 
 def copy_info_plist_fixtures
   FileUtils.mkdir_p("/tmp/fastlane/tests/fastlane/plist")
+
+  copy_non_literal_style_plist("InfoV2.plist")
+  copy_literal_value_style_plist
+end
+
+def copy_literal_value_style_plist(filename = "Info.plist")
+  FileUtils.mkdir_p("/tmp/fastlane/tests/fastlane/plist")
   source = "./spec/fixtures/plist/Info.plist"
-  destination = "/tmp/fastlane/tests/fastlane/plist/Info.plist" #copy old literal value style plist
+  destination = File.join("/tmp/fastlane/tests/fastlane/plist/", filename)
 
   FileUtils.cp_r(source, destination)
+end
 
+def copy_non_literal_style_plist(filename = "Info.plist")
+  FileUtils.mkdir_p("/tmp/fastlane/tests/fastlane/plist")
   source = "./spec/fixtures/plist/New-Info.plist"
-  destination = "/tmp/fastlane/tests/fastlane/plist/InfoV2.plist" #copy new non-literal value style plist
+  destination = File.join("/tmp/fastlane/tests/fastlane/plist/", filename)
   FileUtils.cp_r(source, destination)
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,31 +6,52 @@ end
 
 require 'fastlane' # to import the Action super class
 require 'fastlane/plugin/versioning' # import the actual plugin
+require 'webmock/rspec'
 
 Fastlane.load_actions # load other actions (in case your plugin calls other actions or shared values)
 
-def copy_info_plist_fixture
-  FileUtils.mkdir_p("/tmp/fastlane/tests/fastlane")
-  source = "./spec/fixtures/plist/Info.plist"
-  destination = "/tmp/fastlane/tests/fastlane/Info.plist"
+def fake_api_responses
+  source = "./spec/fixtures/responses/"
+  destination = "/tmp/fastlane/tests/fastlane/responses/"
 
+  FileUtils.cp_r(source, destination)
+
+  fake_existing_response = File.read(File.join(destination, '/numbers_lookup_response'))
+  stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.apple.Numbers").to_return(fake_existing_response)
+  fake_nonexistent_response = File.read(File.join(destination, '/nonexistent_lookup_response'))
+  stub_request(:get, "http://itunes.apple.com/lookup?bundleId=com.some.nonexistent.app").to_return(fake_nonexistent_response)
+end
+
+def copy_info_plist_fixtures
+  FileUtils.mkdir_p("/tmp/fastlane/tests/fastlane/plist")
+  source = "./spec/fixtures/plist/Info.plist"
+  destination = "/tmp/fastlane/tests/fastlane/plist/Info.plist" #copy old literal value style plist
+
+  FileUtils.cp_r(source, destination)
+
+  source = "./spec/fixtures/plist/New-Info.plist"
+  destination = "/tmp/fastlane/tests/fastlane/plist/InfoV2.plist" #copy new non-literal value style plist
   FileUtils.cp_r(source, destination)
 end
 
 def remove_info_plist_fixture
-  FileUtils.rm_r("/tmp/fastlane/tests/fastlane")
+  FileUtils.rm_r("/tmp/fastlane/tests/fastlane/plist")
 end
 
 def copy_xcodeproj_fixtures
   # Create test folder
-  FileUtils.mkdir_p("/tmp/fastlane/tests/fastlane")
+  FileUtils.mkdir_p("/tmp/fastlane/tests/fastlane/xcodeproj")
   source = "./spec/fixtures/xcodeproj"
-  destination = "/tmp/fastlane/tests/fastlane/xcodeproj"
+  destination = "/tmp/fastlane/tests/fastlane"
 
   # Copy .xcodeproj fixtures, as it will be modified during the test
   FileUtils.cp_r(source, destination)
 end
 
 def remove_xcodeproj_fixtures
+  FileUtils.rm_r("/tmp/fastlane/tests/fastlane/xcodeproj")
+end
+
+def cleanup_fixtures
   FileUtils.rm_r("/tmp/fastlane/tests/fastlane")
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,17 @@ end
 def remove_info_plist_fixture
   FileUtils.rm_r("/tmp/fastlane/tests/fastlane")
 end
+
+def copy_xcodeproj_fixtures
+  # Create test folder
+  FileUtils.mkdir_p("/tmp/fastlane/tests/fastlane")
+  source = "./spec/fixtures/xcodeproj"
+  destination = "/tmp/fastlane/tests/fastlane/xcodeproj"
+
+  # Copy .xcodeproj fixtures, as it will be modified during the test
+  FileUtils.cp_r(source, destination)
+end
+
+def remove_xcodeproj_fixtures
+  FileUtils.rm_r("/tmp/fastlane/tests/fastlane")
+end


### PR DESCRIPTION
as a result of xcode 11's new ..opinion.. on where to store the actual values for build number and version number, we need some way to interact with the new storage 'solution' -- the xcodeproj's -- in a fastlane context. 

given a lot of people come to this plugin for such an ability - I humbly open this PR.

This PR adds a new flag `plist_build_setting_support` to the existing plist increment actions - with a default value of false - that when set to true, will jump to the new actions - the increment/get build/version from xcodeproj's.

Please have a read - and let me know anything you can suggest!

_note: I did run a formatter on all the files - and you might notice some differences in formatting (i.e. the array literals of symbols, for example). If you dislike this, please let me know how you've consistently formatted the code and I'll setup my env to do the same_