### PR TITLE
Fixes increment_build_number_in_xcodeproj in xocde 11

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
@@ -57,7 +57,7 @@ module Fastlane
 
         if !(build_configuration_name = params[:build_configuration_name]).nil?
           build_number = build_number[build_configuration_name]
-          UI.user_error! "Cannot resolve $(CURRENT_PROJECT_VERSION) build setting for #{build_configuration_name}." if plist.nil?
+          UI.user_error! "Cannot resolve $(CURRENT_PROJECT_VERSION) build setting for #{build_configuration_name}." if build_number.nil?
         else
           build_number = build_number.values.compact.uniq
           UI.user_error! 'Cannot accurately resolve $(CURRENT_PROJECT_VERSION) build setting, try specifying :build_configuration_name.' if build_number.count > 1

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
@@ -87,7 +87,7 @@ module Fastlane
         project.save
       end
 
-      def self.set_build_version_using_scheme(params, next_version_number)
+      def self.set_version_number_using_scheme(params, next_version_number)
         config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
         project = FastlaneCore::Project.new(config)
         project.select_scheme

--- a/spec/increment_build_number_in_xcodeproj_spec.rb
+++ b/spec/increment_build_number_in_xcodeproj_spec.rb
@@ -46,6 +46,40 @@ describe Fastlane::Actions::IncrementBuildNumberInXcodeprojAction do
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::BUILD_NUMBER]).to eq("22")
     end
 
+
+    it "should not crash when specifying build configuration name, target and project" do
+      file = Fastlane::FastFile.new.parse("
+        lane :increment do
+          increment_build_number_in_xcodeproj(
+            xcodeproj: '/tmp/fastlane/tests/fastlane/xcodeproj/versioning_fixture_project.xcodeproj',
+            target: 'versioning_fixture_project',
+            build_configuration_name: 'Release'
+          )
+        end")
+        
+        expect { 
+          result = file.runner.execute(:increment)
+          expect(result).to eq("2")
+        }.not_to raise_error
+    end
+
+    it "should not crash when specifying  build configuration name, target, project and build number" do
+      file = Fastlane::FastFile.new.parse("
+        lane :increment do
+          increment_build_number_in_xcodeproj(
+            xcodeproj: '/tmp/fastlane/tests/fastlane/xcodeproj/versioning_fixture_project.xcodeproj',
+            target: 'versioning_fixture_project',
+            build_configuration_name: 'Release',
+            build_number: '50'
+          )
+        end")
+        
+        expect { 
+          result = file.runner.execute(:increment)
+          expect(result).to eq("50")
+        }.not_to raise_error
+    end
+    
     after do
       cleanup_fixtures
     end

--- a/spec/increment_version_number_in_xcodeproj_spec.rb
+++ b/spec/increment_version_number_in_xcodeproj_spec.rb
@@ -94,7 +94,7 @@ describe Fastlane::Actions::IncrementVersionNumberInXcodeprojAction do
       expect(current_target_version).to eq("1.0.0")
       expect(Fastlane::Actions.lane_context[Fastlane::Actions::SharedValues::VERSION_NUMBER]).to eq("1.0.0")
     end
-
+    
     after do
       cleanup_fixtures
     end


### PR DESCRIPTION
## Error


> [23:35:08]: -------------------------------------------------
[23:35:08]: --- Step: increment_build_number_in_xcodeproj ---
[23:35:08]: -------------------------------------------------
[23:35:09]: Unknown method 'plist'
[23:35:09]: To call another action from an action use `other_action.plist` instead
+------+-------------------------------------+-------------+
|                     fastlane summary                     |
+------+-------------------------------------+-------------+
| Step | Action                              | Time (in s) |
+------+-------------------------------------+-------------+
| 💥   | increment_build_number_in_xcodeproj | 0           |
+------+-------------------------------------+-------------+
[23:35:09]: fastlane finished with errors
[!] To call another action from an action use `other_action.plist` instead

## Fastfile to reproduce

```
lane :increment do
  increment_build_number_in_xcodeproj(
    xcodeproj: '<your-xcodeproject>',
    target: <target>,
    build_configuration_name: <Release>
  )
end
```

## Fix

Looks like an incorrect comparison. The plugin works fine after the change.

