### PR TITLE
github actions' support for ci_build_number

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/ci_build_number.rb
+++ b/lib/fastlane/plugin/versioning/actions/ci_build_number.rb
@@ -50,6 +50,10 @@ module Fastlane
           return ENV['APPVEYOR_BUILD_NUMBER']
         end
 
+        if ENV.key?('GITHUB_RUN_NUMBER')
+          return ENV['GITHUB_RUN_NUMBER']
+        end
+
         UI.error("Cannot detect current CI build number. Defaulting to \"1\".")
         "1"
       end

--- a/spec/ci_build_number_spec.rb
+++ b/spec/ci_build_number_spec.rb
@@ -180,6 +180,18 @@ describe Fastlane::Actions::CiBuildNumberAction do
       ENV.delete('APPVEYOR_BUILD_NUMBER')
     end
 
+    it "Returns build number defined in GITHUB_RUN_NUMBER environment variable if running on Github Actions" do
+      ENV['GITHUB_RUN_NUMBER'] = '42'
+
+      result = Fastlane::FastFile.new.parse("lane :test do
+          ci_build_number
+        end").runner.execute(:test)
+
+      expect(result).to eq('42')
+
+      ENV.delete('GITHUB_RUN_NUMBER')
+    end
+
     it "Uses 1 as a default build number if cannot detect" do
       result = Fastlane::FastFile.new.parse("lane :test do
         ci_build_number


### PR DESCRIPTION
According to [Github Actions docs](https://docs.github.com/en/actions/reference/environment-variables#default-environment-variables) which says:

_A unique number for each run of a particular workflow in a repository. This number begins at 1 for the workflow's first run, and increments with each new run. This number does not change if you re-run the workflow run._