### PR TITLE
Fix ignore configuration when we use increment_build_number or  increment_app_version in xcodeproj with target and build_configuration_name

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
@@ -59,10 +59,16 @@ module Fastlane
           target = project.targets[0] if target.nil?
         end
 
-        target.build_configurations.each do |config|
+        if params[:build_configuration_name]
+          config = target.build_configurations.detect { |c| c.name == params[:build_configuration_name]}
+          UI.message "updating #{config.name} to build #{next_build_number}"
+          config.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number
+        else
+          target.build_configurations.each do |config|
           UI.message "updating #{config.name} to build #{next_build_number}"
           config.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number
         end unless target.nil?
+        end
 
         project.save
       end

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
@@ -65,9 +65,9 @@ module Fastlane
           config.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number
         else
           target.build_configurations.each do |config|
-          UI.message "updating #{config.name} to build #{next_build_number}"
-          config.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number
-        end unless target.nil?
+            UI.message "updating #{config.name} to build #{next_build_number}"
+            config.build_settings["CURRENT_PROJECT_VERSION"] = next_build_number
+          end unless target.nil?
         end
 
         project.save

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
@@ -79,10 +79,17 @@ module Fastlane
           target = project.targets[0] if target.nil?
         end
 
-        target.build_configurations.each do |config|
+        if params[:build_configuration_name]
+          config = target.build_configurations.detect { |c| c.name == params[:build_configuration_name]}
+          UI.message "updating #{config.name} to version #{next_version_number}"
+          config.build_settings["MARKETING_VERSION"] = next_version_number
+        else
+          target.build_configurations.each do |config|
           UI.message "updating #{config.name} to version #{next_version_number}"
           config.build_settings["MARKETING_VERSION"] = next_version_number
         end unless target.nil?
+        end
+
 
         project.save
       end

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
@@ -85,9 +85,9 @@ module Fastlane
           config.build_settings["MARKETING_VERSION"] = next_version_number
         else
           target.build_configurations.each do |config|
-          UI.message "updating #{config.name} to version #{next_version_number}"
-          config.build_settings["MARKETING_VERSION"] = next_version_number
-        end unless target.nil?
+            UI.message "updating #{config.name} to version #{next_version_number}"
+            config.build_settings["MARKETING_VERSION"] = next_version_number
+          end unless target.nil?
         end
 
 


### PR DESCRIPTION
This pull request fixes an issue when we use increment_build_number_in_xcodeproj or increment_version_number_in_xcodeproj passing in the target and build_configuration_name options. Before the fix, action changed values in both configurations at once