### PR TITLE
Resolve build settings to see if `PRODUCT_BUNDLE_IDENTIFIER` is present

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
@@ -34,7 +34,7 @@ module Fastlane
 
       private_class_method
       def self.select_build_configuration_predicate(name, configuration)
-        is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.build_settings["PRODUCT_BUNDLE_IDENTIFIER"].nil?
+        is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.resolve_build_setting('PRODUCT_BUNDLE_IDENTIFIER').nil?
         is_build_valid_configuration &&= configuration.name == name unless name.nil?
         return is_build_valid_configuration
       end

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
@@ -41,7 +41,7 @@ module Fastlane
 
       private_class_method
       def self.select_build_configuration_predicate(name, configuration)
-        is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.build_settings["PRODUCT_BUNDLE_IDENTIFIER"].nil?
+        is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.resolve_build_setting('PRODUCT_BUNDLE_IDENTIFIER').nil?
         is_build_valid_configuration &&= configuration.name == name unless name.nil?
         return is_build_valid_configuration
       end

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
@@ -61,7 +61,7 @@ module Fastlane
 
       private_class_method
       def self.select_build_configuration_predicate(name, configuration)
-        is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.build_settings["PRODUCT_BUNDLE_IDENTIFIER"].nil?
+        is_build_valid_configuration = configuration.isa == "XCBuildConfiguration" && !configuration.resolve_build_setting('PRODUCT_BUNDLE_IDENTIFIER').nil?
         is_build_valid_configuration &&= configuration.name == name unless name.nil?
         return is_build_valid_configuration
       end


### PR DESCRIPTION
Some projects might utilize config files, or might just inherit the root project settings.

To support these setup, instead of just seeing the build configuration only, this PR makes it to resolve the configuration to see if `PRODUCT_BUNDLE_IDENTIFIER` is present.

API doc is available here: https://www.rubydoc.info/gems/xcodeproj/Xcodeproj%2FProject%2FObject%2FXCBuildConfiguration:resolve_build_setting
