### PR TITLE
Add random query param to get_app_store_version_number.rb

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/get_app_store_version_number.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_app_store_version_number.rb
@@ -3,6 +3,7 @@ module Fastlane
     class GetAppStoreVersionNumberAction < Action
 
       require 'json'
+      require 'securerandom'
 
       def self.run(params)
         if params[:bundle_id]
@@ -17,9 +18,9 @@ module Fastlane
         end
 
         if params[:country]
-          uri = URI("http://itunes.apple.com/lookup?bundleId=#{bundle_id}&country=#{params[:country]}")
+          uri = URI("http://itunes.apple.com/lookup?bundleId=#{bundle_id}&country=#{params[:country]}&rand=#{SecureRandom.uuid}")
         else
-          uri = URI("http://itunes.apple.com/lookup?bundleId=#{bundle_id}")
+          uri = URI("http://itunes.apple.com/lookup?bundleId=#{bundle_id}&rand=#{SecureRandom.uuid}")
         end
         Net::HTTP.get(uri)
 


### PR DESCRIPTION
Apple has a 24 hour cache on the response that comes back from itunes.apple.com/lookup.
This has caused problems in our builds because we use this plugin to detect in CI whether a new version should be released and if CI is run twice within 24 hours, we end up getting a cached value back from Apple.

This PR adds a tiny random uuid query param to bust the cache & get a fresh response.