### PR TITLE
Add `skip_package_dependencies_resolution` support

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/get_app_store_version_number.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_app_store_version_number.rb
@@ -77,7 +77,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :country,
                              optional: true,
                              description: "Pass an optional country code, if your app's availability is limited to specific countries",
-                             is_string: true)
+                             is_string: true),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                             description: "Skips resolution of Swift Package Manager dependencies",
+                             type: Boolean,
+                             default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_plist.rb
@@ -62,7 +62,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                               description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                               is_string: false,
-                              default_value: false)
+                              default_value: false),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                               description: "Skips resolution of Swift Package Manager dependencies",
+                               type: Boolean,
+                               default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
@@ -68,7 +68,12 @@ module Fastlane
       end
 
       def self.get_build_number_using_scheme(params)
-        config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
+        config = {
+          project: params[:xcodeproj],
+          scheme: params[:scheme],
+          configuration: params[:build_configuration_name],
+          skip_package_dependencies_resolution: params[:skip_package_dependencies_resolution]
+        }
         project = FastlaneCore::Project.new(config)
         project.select_scheme
 
@@ -111,7 +116,11 @@ module Fastlane
                                        description: "Specify a specific scheme if you have multiple per project, optional"),
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                                        optional: true,
-                                       description: "Specify a specific build configuration if you have different build settings for each configuration")
+                                       description: "Specify a specific build configuration if you have different build settings for each configuration"),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                                       description: "Skips resolution of Swift Package Manager dependencies",
+                                       type: Boolean,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_info_plist_path.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_info_plist_path.rb
@@ -53,7 +53,12 @@ module Fastlane
       end
 
       def self.find_path_using_scheme(params)
-        config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
+        config = {
+          project: params[:xcodeproj],
+          scheme: params[:scheme],
+          configuration: params[:build_configuration_name],
+          skip_package_dependencies_resolution: params[:skip_package_dependencies_resolution]
+        }
         project = FastlaneCore::Project.new(config)
         project.select_scheme
 
@@ -98,7 +103,11 @@ module Fastlane
                                        description: "Specify a specific scheme if you have multiple per project, optional"),
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                                        optional: true,
-                                       description: "Specify a specific build configuration if you have different Info.plist build settings for each configuration")
+                                       description: "Specify a specific build configuration if you have different Info.plist build settings for each configuration"),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                                       description: "Skips resolution of Swift Package Manager dependencies",
+                                       type: Boolean,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_plist.rb
@@ -60,9 +60,13 @@
                              optional: true,
                              description: "Specify a specific build configuration if you have different Info.plist build settings for each configuration"),
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
-                            description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
-                            is_string: false,
-                            default_value: false)
+                             description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
+                             is_string: false,
+                             default_value: false),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                             description: "Skips resolution of Swift Package Manager dependencies",
+                             type: Boolean,
+                             default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
@@ -52,7 +52,12 @@ module Fastlane
       end
 
       def self.get_version_number_using_scheme(params)
-        config = { project: params[:xcodeproj], scheme: params[:scheme], configuration: params[:build_configuration_name] }
+        config = {
+          project: params[:xcodeproj],
+          scheme: params[:scheme],
+          configuration: params[:build_configuration_name],
+          skip_package_dependencies_resolution: params[:skip_package_dependencies_resolution]
+        }
         project = FastlaneCore::Project.new(config)
         project.select_scheme
 
@@ -95,7 +100,11 @@ module Fastlane
                                        description: "Specify a specific scheme if you have multiple per project, optional"),
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                                        optional: true,
-                                       description: "Specify a specific build configuration if you have different build settings for each configuration")
+                                       description: "Specify a specific build configuration if you have different build settings for each configuration"),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                                       description: "Skips resolution of Swift Package Manager dependencies",
+                                       type: Boolean,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_plist.rb
@@ -82,9 +82,13 @@ module Fastlane
                                        optional: true,
                                        description: "Specify a specific build configuration if you have different Info.plist build settings for each configuration"),
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
-                                        description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
-                                        is_string: false,
-                                        default_value: false)
+                                       description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
+                                       is_string: false,
+                                       default_value: false),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                                       description: "Skips resolution of Swift Package Manager dependencies",
+                                       type: Boolean,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_build_number_in_xcodeproj.rb
@@ -117,7 +117,11 @@ module Fastlane
                                          description: "Specify a specific scheme if you have multiple per project, optional"),
           FastlaneCore::ConfigItem.new(key: :build_configuration_name,
                                          optional: true,
-                                         description: "Specify a specific build configuration if you have different build settings for each configuration")
+                                         description: "Specify a specific build configuration if you have different build settings for each configuration"),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                                         description: "Skips resolution of Swift Package Manager dependencies",
+                                         type: Boolean,
+                                         default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_plist.rb
@@ -136,7 +136,11 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                                         description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                                         is_string: false,
-                                        default_value: false)
+                                        default_value: false),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                                       description: "Skips resolution of Swift Package Manager dependencies",
+                                       type: Boolean,
+                                       default_value: false)
         ]
       end
 

--- a/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/increment_version_number_in_xcodeproj.rb
@@ -173,6 +173,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :plist_build_setting_support,
                          description: "support automatic resolution of build setting from xcodeproj if not a literal value in the plist",
                          is_string: false,
+                         default_value: false),
+          FastlaneCore::ConfigItem.new(key: :skip_package_dependencies_resolution,
+                         description: "Skips resolution of Swift Package Manager dependencies",
+                         type: Boolean,
                          default_value: false)
         ]
       end


### PR DESCRIPTION
Similar to https://github.com/fastlane/fastlane/pull/17916, this PR introduces `skip_package_dependencies_resolution` support to the current plugin.