### PR TITLE
Fixing logging in `get_build_number_from_xcodeproj`/`get_version_number_from_xcodeproj`

### DIFF
--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
@@ -78,7 +78,7 @@ module Fastlane
         project.select_scheme
 
         build_number = project.build_settings(key: 'CURRENT_PROJECT_VERSION')
-        UI.user_error! "Cannot resolve $(CURRENT_PROJECT_VERSION) in for the scheme #{config.scheme} with the name #{params.configuration}" if build_number.nil? || build_number.empty?
+        UI.user_error! "Cannot resolve $(CURRENT_PROJECT_VERSION) in for the scheme #{config[:scheme]} with the name #{params[:configuration]}" if build_number.nil? || build_number.empty?
         build_number
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_build_number_from_xcodeproj.rb
@@ -78,7 +78,7 @@ module Fastlane
         project.select_scheme
 
         build_number = project.build_settings(key: 'CURRENT_PROJECT_VERSION')
-        UI.user_error! "Cannot resolve $(CURRENT_PROJECT_VERSION) in for the scheme #{config[:scheme]} with the name #{params[:configuration]}" if build_number.nil? || build_number.empty?
+        UI.user_error! "Cannot resolve $(CURRENT_PROJECT_VERSION) in for the scheme #{config[:scheme]} with the name #{config[:configuration]}" if build_number.nil? || build_number.empty?
         build_number
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
@@ -62,7 +62,7 @@ module Fastlane
         project.select_scheme
 
         build_number = project.build_settings(key: 'MARKETING_VERSION')
-        UI.user_error! "Cannot resolve $(MARKETING_VERSION) in for the scheme #{config.scheme} with the name #{params.configuration}" if build_number.nil? || build_number.empty?
+        UI.user_error! "Cannot resolve $(MARKETING_VERSION) in for the scheme #{config[:scheme]} with the name #{params[:configuration]}" if build_number.nil? || build_number.empty?
         build_number
       end
 

--- a/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
+++ b/lib/fastlane/plugin/versioning/actions/get_version_number_from_xcodeproj.rb
@@ -62,7 +62,7 @@ module Fastlane
         project.select_scheme
 
         build_number = project.build_settings(key: 'MARKETING_VERSION')
-        UI.user_error! "Cannot resolve $(MARKETING_VERSION) in for the scheme #{config[:scheme]} with the name #{params[:configuration]}" if build_number.nil? || build_number.empty?
+        UI.user_error! "Cannot resolve $(MARKETING_VERSION) in for the scheme #{config[:scheme]} with the name #{config[:configuration]}" if build_number.nil? || build_number.empty?
         build_number
       end
 


### PR DESCRIPTION
This fixes the issue mentioned in #100 

The `Hash` was being accessed in an incorrect manner, should use `hash[:property]` instead of `hash.property`.
Changing the syntax fixed the issue :D 